### PR TITLE
replace src folder with top-level folder

### DIFF
--- a/editor_support/sublime_text/uproxylib.sublime-project
+++ b/editor_support/sublime_text/uproxylib.sublime-project
@@ -1,14 +1,14 @@
 {
   "folders": [
     {
-      "path": "../../src",
-      "name": "src",
+      "path": "../../build/typescript-src",
+      "name": "build/typescript-src",
+      "follow_symlinks": true,
     },
     {
-      "path": "../../build/typescript-src",
-      "name": "build/ypescript-src",
-      "follow_symlinks": true
-    }
+      "path": "../..",
+      "name": "uproxy-lib",
+    },
   ],
   "settings": {
     "tab_size": 2,


### PR DESCRIPTION
I often find it useful to edit non-source files in Sublime Text, too.

This removes the `src` folder, replacing it with a "top-level" folder called `uproxy-lib`.

Thoughts?
