### PR TITLE
tweaked/idealized uproxypeerconnection interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"

--- a/src/coreproviders/interfaces/uproxypeerconnection.ts
+++ b/src/coreproviders/interfaces/uproxypeerconnection.ts
@@ -92,12 +92,14 @@ fdom.apis.set('core.uproxypeerconnection', {
     ]
   },
 
-  'peerOpenedChannel': {
-    type: 'event',
-    value: 'string'
+  'onceDataChannelClosed': {
+    type: 'method',
+    value: [
+      'string'
+    ]
   },
 
-  'peerClosedChannel': {
+  'peerOpenedChannel': {
     type: 'event',
     value: 'string'
   },

--- a/src/coreproviders/interfaces/uproxypeerconnection.ts
+++ b/src/coreproviders/interfaces/uproxypeerconnection.ts
@@ -39,7 +39,7 @@ fdom.apis.set('core.uproxypeerconnection', {
     value: 'object'
   },
 
-  'signalMessageForPeer': {
+  'signalForPeer': {
     type: 'event',
     value: 'object'
   },

--- a/src/coreproviders/interfaces/uproxypeerconnection.ts
+++ b/src/coreproviders/interfaces/uproxypeerconnection.ts
@@ -39,7 +39,7 @@ fdom.apis.set('core.uproxypeerconnection', {
     value: 'object'
   },
 
-  'signalMessage': {
+  'signalMessageToPeer': {
     type: 'event',
     value: 'object'
   },
@@ -85,7 +85,7 @@ fdom.apis.set('core.uproxypeerconnection', {
     value: 'string'
   },
 
-  'fromPeerData': {
+  'dataFromPeer': {
     type: 'event',
     value: {
       'channelLabel': 'string',

--- a/src/coreproviders/interfaces/uproxypeerconnection.ts
+++ b/src/coreproviders/interfaces/uproxypeerconnection.ts
@@ -39,7 +39,7 @@ fdom.apis.set('core.uproxypeerconnection', {
     value: 'object'
   },
 
-  'signalMessageToPeer': {
+  'signalMessageForPeer': {
     type: 'event',
     value: 'object'
   },

--- a/src/coreproviders/interfaces/uproxypeerconnection.ts
+++ b/src/coreproviders/interfaces/uproxypeerconnection.ts
@@ -34,6 +34,11 @@ fdom.apis.set('core.uproxypeerconnection', {
     }
   },
 
+  'close': {
+    type: 'method',
+    value: []
+  },
+
   'handleSignalMessage': {
     type: 'method',
     value: 'object'
@@ -80,7 +85,19 @@ fdom.apis.set('core.uproxypeerconnection', {
     ]
   },
 
-  'peerCreatedChannel': {
+  'closeDataChannel': {
+    type: 'method',
+    value: [
+      'string'
+    ]
+  },
+
+  'peerOpenedChannel': {
+    type: 'event',
+    value: 'string'
+  },
+
+  'peerClosedChannel': {
     type: 'event',
     value: 'string'
   },

--- a/src/coreproviders/providers/uproxypeerconnection.d.ts
+++ b/src/coreproviders/providers/uproxypeerconnection.d.ts
@@ -26,8 +26,8 @@ declare module freedom_UproxyPeerConnection {
   // arguments, the implementation of this class accepts a
   // PeerConnectionConfig instance.
   interface Pc {
-
-    negotiateConnection() : Promise<WebRtc.ConnectionAddresses>;
+    negotiateConnection(config:WebRtc.PeerConnectionConfig)
+        : Promise<WebRtc.ConnectionAddresses>;
 
     handleSignalMessage(signal:WebRtc.SignallingMessage) : Promise<void>;
 
@@ -35,6 +35,7 @@ declare module freedom_UproxyPeerConnection {
     // i.e. this is equivalent to PeerConnection.openDataChannel().onceOpened().
     // TODO: add options argument
     openDataChannel(channelLabel: string) : Promise<void>;
+    closeDataChannel(channelLabel: string) : Promise<void>;
 
     // As per PeerConnection, this fulfills once the supplied data
     // has been sucessfully sent to the peer.
@@ -43,22 +44,26 @@ declare module freedom_UproxyPeerConnection {
     // TODO: getState, for both peer connection and data channels
     // TODO: close
 
+    // TODO: onceConnecting and onceDisconnected
     onceConnected() : Promise<WebRtc.ConnectionAddresses>;
     onceConnecting() : Promise<void>;
     onceDisconnected() : Promise<void>;
+    close() : Promise<void>;
 
     // TODO: make a type for events from UproxyPeerConnection and use the same
     // type in the implementation. That way you can get better typechecking.
     // e.g.
     // interface Message {
-    //  onSignalMessage: string;
+    //  signalMessage: string;
     //  peerCreatedChannel: string;
     //  fromPeerData: LabelledDataChannelMessage;
     //}
     on(t:string, f:(eventData:any) => void) : void;
-    on(t:'onSignalMessage', f:(signal:WebRtc.SignallingMessage) => void) : void;
-    on(t:'peerCreatedChannel', f:(channelLabel:string) => void) : void;
-    on(t:'fromPeerData', f:(message:LabelledDataChannelMessage) => void)
-        : void;
+    on(t:'signalMessageToPeer',
+       f:(signal:WebRtc.SignallingMessage) => void) : void;
+    on(t:'peerOpenedChannel', f:(channelLabel:string) => void) : void;
+    on(t:'peerClosedChannel', f:(channelLabel:string) => void) : void;
+    on(t:'dataFromPeer',
+       f:(message:LabelledDataChannelMessage) => void) : void;
   }
 }

--- a/src/coreproviders/providers/uproxypeerconnection.d.ts
+++ b/src/coreproviders/providers/uproxypeerconnection.d.ts
@@ -40,6 +40,7 @@ declare module freedom_UproxyPeerConnection {
     //   PeerConnection.openDataChannel().onceOpened()
     openDataChannel(channelLabel: string) : Promise<void>;
     closeDataChannel(channelLabel: string) : Promise<void>;
+    onceDataChannelClosed(channelLabel:string) : Promise<void>;
 
     // As per PeerConnection, this fulfills once the supplied data
     // has been sucessfully sent to the peer.
@@ -55,7 +56,6 @@ declare module freedom_UproxyPeerConnection {
     on(t:'signalForPeer',
        f:(signal:WebRtc.SignallingMessage) => void) : void;
     on(t:'peerOpenedChannel', f:(channelLabel:string) => void) : void;
-    on(t:'peerClosedChannel', f:(channelLabel:string) => void) : void;
     on(t:'dataFromPeer',
        f:(message:LabelledDataChannelMessage) => void) : void;
   }

--- a/src/coreproviders/providers/uproxypeerconnection.d.ts
+++ b/src/coreproviders/providers/uproxypeerconnection.d.ts
@@ -26,8 +26,12 @@ declare module freedom_UproxyPeerConnection {
   // arguments, the implementation of this class accepts a
   // PeerConnectionConfig instance.
   interface Pc {
-    negotiateConnection(config:WebRtc.PeerConnectionConfig)
-        : Promise<WebRtc.ConnectionAddresses>;
+    // Note: the constructor is done in the
+    // style of freedom['provider-name'](args)
+    //
+    // constructor(config:WebRtc.PeerConnectionConfig);
+
+    negotiateConnection() : Promise<WebRtc.ConnectionAddresses>;
 
     handleSignalMessage(signal:WebRtc.SignallingMessage) : Promise<void>;
 
@@ -42,9 +46,6 @@ declare module freedom_UproxyPeerConnection {
     send(channelLabel:string, data:WebRtc.Data) : Promise<void>;
 
     // TODO: getState, for both peer connection and data channels
-    // TODO: close
-
-    // TODO: onceConnecting and onceDisconnected
     onceConnected() : Promise<WebRtc.ConnectionAddresses>;
     onceConnecting() : Promise<void>;
     onceDisconnected() : Promise<void>;
@@ -59,7 +60,7 @@ declare module freedom_UproxyPeerConnection {
     //  fromPeerData: LabelledDataChannelMessage;
     //}
     on(t:string, f:(eventData:any) => void) : void;
-    on(t:'signalMessageToPeer',
+    on(t:'signalMessageForPeer',
        f:(signal:WebRtc.SignallingMessage) => void) : void;
     on(t:'peerOpenedChannel', f:(channelLabel:string) => void) : void;
     on(t:'peerClosedChannel', f:(channelLabel:string) => void) : void;

--- a/src/coreproviders/providers/uproxypeerconnection.d.ts
+++ b/src/coreproviders/providers/uproxypeerconnection.d.ts
@@ -51,14 +51,6 @@ declare module freedom_UproxyPeerConnection {
     onceDisconnected() : Promise<void>;
     close() : Promise<void>;
 
-    // TODO: make a type for events from UproxyPeerConnection and use the same
-    // type in the implementation. That way you can get better typechecking.
-    // e.g.
-    // interface Message {
-    //  signalMessage: string;
-    //  peerCreatedChannel: string;
-    //  fromPeerData: LabelledDataChannelMessage;
-    //}
     on(t:string, f:(eventData:any) => void) : void;
     on(t:'signalForPeer',
        f:(signal:WebRtc.SignallingMessage) => void) : void;

--- a/src/coreproviders/providers/uproxypeerconnection.d.ts
+++ b/src/coreproviders/providers/uproxypeerconnection.d.ts
@@ -36,8 +36,8 @@ declare module freedom_UproxyPeerConnection {
     handleSignalMessage(signal:WebRtc.SignallingMessage) : Promise<void>;
 
     // Fulfills once the data channel has been successfully opened,
-    // i.e. this is equivalent to PeerConnection.openDataChannel().onceOpened().
-    // TODO: add options argument
+    // i.e. this is equivalent to
+    //   PeerConnection.openDataChannel().onceOpened()
     openDataChannel(channelLabel: string) : Promise<void>;
     closeDataChannel(channelLabel: string) : Promise<void>;
 
@@ -60,7 +60,7 @@ declare module freedom_UproxyPeerConnection {
     //  fromPeerData: LabelledDataChannelMessage;
     //}
     on(t:string, f:(eventData:any) => void) : void;
-    on(t:'signalMessageForPeer',
+    on(t:'signalForPeer',
        f:(signal:WebRtc.SignallingMessage) => void) : void;
     on(t:'peerOpenedChannel', f:(channelLabel:string) => void) : void;
     on(t:'peerClosedChannel', f:(channelLabel:string) => void) : void;

--- a/src/coreproviders/providers/uproxypeerconnection.ts
+++ b/src/coreproviders/providers/uproxypeerconnection.ts
@@ -67,6 +67,11 @@ class UproxyPeerConnectionImpl {
   //---------------------------------------------------------------------------
   // Data channels.
 
+  public onceDataChannelClosed =
+      (channelLabel:string, continuation:() => void) : void => {
+    this.pc_.dataChannels[channelLabel].onceClosed.then(continuation);
+  }
+
   // Re-dispatches data channel events, such as receiving data, as
   // Freedom messages.
   private dispatchDataChannelEvents_ = (dataChannel:WebRtc.DataChannel) => {
@@ -74,9 +79,6 @@ class UproxyPeerConnectionImpl {
       this.dispatchEvent_('dataFromPeer',
         { channelLabel: dataChannel.getLabel(),
           message: data });
-    });
-    dataChannel.onceClosed.then(() => {
-      this.dispatchEvent_('closeDataChannel', dataChannel.getLabel());
     });
   }
 

--- a/src/coreproviders/providers/uproxypeerconnection.ts
+++ b/src/coreproviders/providers/uproxypeerconnection.ts
@@ -18,7 +18,7 @@ class UproxyPeerConnectionImpl {
 
     // Re-dispatch various messages as Freedom messages.
     this.pc_.toPeerSignalQueue.setSyncHandler((signal:WebRtc.SignallingMessage) => {
-      this.dispatchEvent_('signalMessage', signal);
+      this.dispatchEvent_('signalMessageToPeer', signal);
     });
       this.pc_.peerCreatedChannelQueue.setSyncHandler(
           (dataChannel:WebRtc.DataChannel) => {
@@ -67,7 +67,7 @@ class UproxyPeerConnectionImpl {
   // Freedom messages.
   private dispatchDataChannelEvents_ = (dataChannel:WebRtc.DataChannel) => {
     dataChannel.fromPeerDataQueue.setSyncHandler((data:WebRtc.Data) => {
-      this.dispatchEvent_('fromPeerData', {
+      this.dispatchEvent_('dataFromPeer', {
         channelLabel: dataChannel.getLabel(),
         message: {
           str: data.str,

--- a/src/coreproviders/providers/uproxypeerconnection.ts
+++ b/src/coreproviders/providers/uproxypeerconnection.ts
@@ -19,7 +19,7 @@ class UproxyPeerConnectionImpl {
     // Re-dispatch various messages as Freedom messages.
     this.pc_.signalForPeerQueue.setSyncHandler(
         (signal:WebRtc.SignallingMessage) => {
-      this.dispatchEvent_('signalMessageForPeer', signal);
+      this.dispatchEvent_('signalForPeer', signal);
     });
       this.pc_.peerCreatedChannelQueue.setSyncHandler(
           (dataChannel:WebRtc.DataChannel) => {
@@ -78,9 +78,8 @@ class UproxyPeerConnectionImpl {
     });
   }
 
-  public openDataChannel = (
-      channelLabel :string,
-      continuation :() => void) : void => {
+  public openDataChannel = (channelLabel :string,
+                            continuation :() => void) : void => {
     var dataChannel = this.pc_.openDataChannel(channelLabel);
     dataChannel.onceOpened.then(() => {
       this.dispatchDataChannelEvents_(dataChannel);
@@ -89,10 +88,16 @@ class UproxyPeerConnectionImpl {
     });
   }
 
-  public send = (
-      channelLabel :string,
-      data :WebRtc.Data,
-      continuation :() => void) : void => {
+  public closeDataChannel =
+      (channelLabel :string, continuation :() => void) : void => {
+    var dataChannel = this.pc_.dataChannels[channelLabel];
+    dataChannel.close();
+    continuation();
+  }
+
+  public send = (channelLabel :string,
+                 data :WebRtc.Data,
+                 continuation :() => void) : void => {
     // TODO: propagate errors
     this.pc_.dataChannels[channelLabel].send(data).then(continuation);
   }

--- a/src/coreproviders/providers/uproxypeerconnection.ts
+++ b/src/coreproviders/providers/uproxypeerconnection.ts
@@ -17,8 +17,9 @@ class UproxyPeerConnectionImpl {
     this.pc_ = new WebRtc.PeerConnection(config);
 
     // Re-dispatch various messages as Freedom messages.
-    this.pc_.toPeerSignalQueue.setSyncHandler((signal:WebRtc.SignallingMessage) => {
-      this.dispatchEvent_('signalMessageToPeer', signal);
+    this.pc_.signalForPeerQueue.setSyncHandler(
+        (signal:WebRtc.SignallingMessage) => {
+      this.dispatchEvent_('signalMessageForPeer', signal);
     });
       this.pc_.peerCreatedChannelQueue.setSyncHandler(
           (dataChannel:WebRtc.DataChannel) => {
@@ -66,7 +67,7 @@ class UproxyPeerConnectionImpl {
   // Re-dispatches data channel events, such as receiving data, as
   // Freedom messages.
   private dispatchDataChannelEvents_ = (dataChannel:WebRtc.DataChannel) => {
-    dataChannel.fromPeerDataQueue.setSyncHandler((data:WebRtc.Data) => {
+    dataChannel.dataFromPeerQueue.setSyncHandler((data:WebRtc.Data) => {
       this.dispatchEvent_('dataFromPeer', {
         channelLabel: dataChannel.getLabel(),
         message: {

--- a/src/coreproviders/samples/freedomchat-chromeapp/freedom.ts
+++ b/src/coreproviders/samples/freedomchat-chromeapp/freedom.ts
@@ -21,11 +21,11 @@ var b :PcLib.Pc = freedom['core.uproxypeerconnection'](pcConfig);
 
 // Connect the two signalling channels.
 // Normally, these messages would be sent over the internet.
-a.on('signalMessage', (signal:WebRtc.SignallingMessage) => {
+a.on('signalMessageToPeer', (signal:WebRtc.SignallingMessage) => {
   console.log('signalling channel A message: ' + JSON.stringify(signal));
   b.handleSignalMessage(signal);
 });
-b.on('signalMessage', (signal:WebRtc.SignallingMessage) => {
+b.on('signalMessageToPeer', (signal:WebRtc.SignallingMessage) => {
   console.log('signalling channel B message: ' + JSON.stringify(signal));
   a.handleSignalMessage(signal);
 });
@@ -47,39 +47,53 @@ function logEndpoints(name:string, endpoints:WebRtc.ConnectionAddresses) {
 a.onceConnected().then(logEndpoints.bind(null, 'a'));
 b.onceConnected().then(logEndpoints.bind(null, 'b'));
 
+var pcConfig :WebRtc.PeerConnectionConfig = {
+    webrtcPcConfig: {
+      iceServers: [{url: 'stun:stun.l.google.com:19302'},
+                   {url: 'stun:stun1.l.google.com:19302'},
+                   {url: 'stun:stun2.l.google.com:19302'},
+                   {url: 'stun:stun3.l.google.com:19302'},
+                   {url: 'stun:stun4.l.google.com:19302'}]
+    },
+    webrtcMediaConstraints: {
+      optional: [{DtlsSrtpKeyAgreement: true}]
+    }
+  };
+
 // Negotiate a peerconnection.
 // Once negotiated, enable the UI and add send/receive handlers.
-a.negotiateConnection().then((endpoints:WebRtc.ConnectionAddresses) => {
-  // Send messages over the datachannel, in response to events from the UI.
-  var sendMessage = (pc:PcLib.Pc, message:Chat.Message) => {
-    pc.send('text', { str: message.message }).catch((e) => {
-      console.error('error sending message: ' + e.message);
-    });
-  };
-  freedom.on('sendA', sendMessage.bind(null, a));
-  freedom.on('sendB', sendMessage.bind(null, b));
+a.negotiateConnection(pcConfig)
+  .then((endpoints:WebRtc.ConnectionAddresses) => {
+    // Send messages over the datachannel, in response to events from the UI.
+    var sendMessage = (pc:PcLib.Pc, message:Chat.Message) => {
+      pc.send('text', { str: message.message }).catch((e) => {
+        console.error('error sending message: ' + e.message);
+      });
+    };
+    freedom.on('sendA', sendMessage.bind(null, a));
+    freedom.on('sendB', sendMessage.bind(null, b));
 
-  // Handle messages received on the datachannel(s).
-  // The message is forwarded to the UI.
-  var receiveMessage = (name:string, d:PcLib.LabelledDataChannelMessage) => {
-    if (d.message.str === undefined) {
-      console.error('only text messages are supported');
-      return;
-    }
-    freedom.emit('receive' + name, {
-      message: d.message.str
-    });
-  };
-  a.on('fromPeerData', receiveMessage.bind(null, 'A'));
-  b.on('fromPeerData', receiveMessage.bind(null, 'B'));
+    // Handle messages received on the datachannel(s).
+    // The message is forwarded to the UI.
+    var receiveMessage = (name:string, d:PcLib.LabelledDataChannelMessage) => {
+      if (d.message.str === undefined) {
+        console.error('only text messages are supported');
+        return;
+      }
+      freedom.emit('receive' + name, {
+        message: d.message.str
+      });
+    };
+    a.on('dataFromPeer', receiveMessage.bind(null, 'A'));
+    b.on('dataFromPeer', receiveMessage.bind(null, 'B'));
 
-  a.openDataChannel('text').then(() => {
-    console.log('datachannel open!');
-    freedom.emit('ready', {});
-  }, (e) => {
-    console.error('could not setup datachannel: ' + e.message);
-    freedom.emit('error', {});
+    a.openDataChannel('text').then(() => {
+      console.log('datachannel open!');
+      freedom.emit('ready', {});
+    }, (e) => {
+      console.error('could not setup datachannel: ' + e.message);
+      freedom.emit('error', {});
+    });
+  }, (e:Error) => {
+    console.error('could not negotiate peerconnection: ' + e.message);
   });
-}, (e) => {
-  console.error('could not negotiate peerconnection: ' + e.message);
-});

--- a/src/coreproviders/samples/freedomchat-chromeapp/freedom.ts
+++ b/src/coreproviders/samples/freedomchat-chromeapp/freedom.ts
@@ -21,11 +21,11 @@ var b :PcLib.Pc = freedom['core.uproxypeerconnection'](pcConfig);
 
 // Connect the two signalling channels.
 // Normally, these messages would be sent over the internet.
-a.on('signalMessageToPeer', (signal:WebRtc.SignallingMessage) => {
+a.on('signalMessageForPeer', (signal:WebRtc.SignallingMessage) => {
   console.log('signalling channel A message: ' + JSON.stringify(signal));
   b.handleSignalMessage(signal);
 });
-b.on('signalMessageToPeer', (signal:WebRtc.SignallingMessage) => {
+b.on('signalMessageForPeer', (signal:WebRtc.SignallingMessage) => {
   console.log('signalling channel B message: ' + JSON.stringify(signal));
   a.handleSignalMessage(signal);
 });
@@ -47,22 +47,9 @@ function logEndpoints(name:string, endpoints:WebRtc.ConnectionAddresses) {
 a.onceConnected().then(logEndpoints.bind(null, 'a'));
 b.onceConnected().then(logEndpoints.bind(null, 'b'));
 
-var pcConfig :WebRtc.PeerConnectionConfig = {
-    webrtcPcConfig: {
-      iceServers: [{url: 'stun:stun.l.google.com:19302'},
-                   {url: 'stun:stun1.l.google.com:19302'},
-                   {url: 'stun:stun2.l.google.com:19302'},
-                   {url: 'stun:stun3.l.google.com:19302'},
-                   {url: 'stun:stun4.l.google.com:19302'}]
-    },
-    webrtcMediaConstraints: {
-      optional: [{DtlsSrtpKeyAgreement: true}]
-    }
-  };
-
 // Negotiate a peerconnection.
 // Once negotiated, enable the UI and add send/receive handlers.
-a.negotiateConnection(pcConfig)
+a.negotiateConnection()
   .then((endpoints:WebRtc.ConnectionAddresses) => {
     // Send messages over the datachannel, in response to events from the UI.
     var sendMessage = (pc:PcLib.Pc, message:Chat.Message) => {

--- a/src/coreproviders/samples/freedomchat-chromeapp/freedom.ts
+++ b/src/coreproviders/samples/freedomchat-chromeapp/freedom.ts
@@ -21,11 +21,11 @@ var b :PcLib.Pc = freedom['core.uproxypeerconnection'](pcConfig);
 
 // Connect the two signalling channels.
 // Normally, these messages would be sent over the internet.
-a.on('signalMessageForPeer', (signal:WebRtc.SignallingMessage) => {
+a.on('signalForPeer', (signal:WebRtc.SignallingMessage) => {
   console.log('signalling channel A message: ' + JSON.stringify(signal));
   b.handleSignalMessage(signal);
 });
-b.on('signalMessageForPeer', (signal:WebRtc.SignallingMessage) => {
+b.on('signalForPeer', (signal:WebRtc.SignallingMessage) => {
   console.log('signalling channel B message: ' + JSON.stringify(signal));
   a.handleSignalMessage(signal);
 });

--- a/src/coreproviders/samples/freedomchat-chromeapp/freedom.ts
+++ b/src/coreproviders/samples/freedomchat-chromeapp/freedom.ts
@@ -30,8 +30,8 @@ b.on('signalForPeer', (signal:WebRtc.SignallingMessage) => {
   a.handleSignalMessage(signal);
 });
 
-b.on('peerCreatedChannel', (channelLabel:string) => {
-  console.log('i can see that a created a data channel called ' + channelLabel);
+b.on('peerOpenedChannel', (channelLabel:string) => {
+  console.log('I can see that `a` created a data channel called ' + channelLabel);
 });
 
 a.onceConnecting().then(() => { console.log('a is connecting...'); });

--- a/src/peerconnection/datachannel.d.ts
+++ b/src/peerconnection/datachannel.d.ts
@@ -29,7 +29,7 @@ declare module WebRtc {
 
     // Data from the peer. No data will be added to the queue after |onceClosed|
     // is fulfilled.
-    public fromPeerDataQueue :Handler.Queue<Data, void>;
+    public dataFromPeerQueue :Handler.Queue<Data, void>;
 
     // Send data; promise returns when all the data has been passed on to the
     // undertlying network layer for ending.

--- a/src/peerconnection/datachannel.ts
+++ b/src/peerconnection/datachannel.ts
@@ -50,7 +50,7 @@ module WebRtc {
   //
   export class DataChannel {
 
-    public fromPeerDataQueue      :Handler.Queue<Data,void>;
+    public dataFromPeerQueue      :Handler.Queue<Data,void>;
 
     // The |toPeerDataQueue_| is chunked by the send call and conjection
     // controlled by the handler this class sets.
@@ -74,7 +74,7 @@ module WebRtc {
     // Wrapper for
     constructor(private rtcDataChannel_:RTCDataChannel) {
       this.label_ = this.rtcDataChannel_.label;
-      this.fromPeerDataQueue = new Handler.Queue<Data,void>();
+      this.dataFromPeerQueue = new Handler.Queue<Data,void>();
       this.toPeerDataQueue_ = new Handler.Queue<Data,void>();
       this.onceOpened = new Promise<void>((F,R) => {
           this.rejectOpened_ = R;
@@ -97,8 +97,8 @@ module WebRtc {
 
       // Make sure to reject the onceOpened promise if state went from
       // |connecting| to |close|.
-      this.onceOpened.then(() => { 
-        this.wasOpenned_ = true; 
+      this.onceOpened.then(() => {
+        this.wasOpenned_ = true;
         this.toPeerDataQueue_.setHandler(this.handleSendDataToPeer_);
       });
       this.onceClosed.then(() => {
@@ -111,9 +111,9 @@ module WebRtc {
     // the queue of data from the peer.
     private onDataFromPeer_ = (messageEvent : RTCMessageEvent) : void => {
       if (typeof messageEvent.data === 'string') {
-        this.fromPeerDataQueue.handle({str: messageEvent.data});
+        this.dataFromPeerQueue.handle({str: messageEvent.data});
       } else if (typeof messageEvent.data === 'ArrayBuffer') {
-        this.fromPeerDataQueue.handle({buffer: messageEvent.data});
+        this.dataFromPeerQueue.handle({buffer: messageEvent.data});
       } else {
         console.error('Unexpected data from peer that has type: ' +
             JSON.stringify(messageEvent));

--- a/src/peerconnection/peerconnection.d.ts
+++ b/src/peerconnection/peerconnection.d.ts
@@ -71,7 +71,7 @@ declare module WebRtc {
     public openDataChannel :(channelLabel: string,
                              options?: RTCDataChannelInit) => DataChannel;
     // Or handle data channels opened by the peer (these events will )
-    public peerCreatedChannelQueue :Handler.Queue<DataChannel, void>;
+    public peerOpenedChannelQueue :Handler.Queue<DataChannel, void>;
 
     // The |handleSignalMessage| function should be called with signalling
     // messages from the remote peer.

--- a/src/peerconnection/peerconnection.d.ts
+++ b/src/peerconnection/peerconnection.d.ts
@@ -79,7 +79,7 @@ declare module WebRtc {
     // The underlying handler that holds/handles signals intended to go to the
     // remote peer. A handler should be set that sends messages to the remote
     // peer.
-    public toPeerSignalQueue :Handler.Queue<SignallingMessage, void>;
+    public signalForPeerQueue :Handler.Queue<SignallingMessage, void>;
 
     // Closing the peer connection will close all associated data channels
     // and set |pcState| to |DISCONNECTED| (and hence fulfills

--- a/src/peerconnection/peerconnection.ts
+++ b/src/peerconnection/peerconnection.ts
@@ -123,7 +123,7 @@ module WebRtc {
     public onceDisconnected :Promise<void>;
 
     // Queue of channels opened up by the remote peer.
-    public peerCreatedChannelQueue :Handler.Queue<DataChannel,void>;
+    public peerOpenedChannelQueue :Handler.Queue<DataChannel,void>;
 
     // Signals to be send to the remote peer by this peer.
     public signalForPeerQueue :Handler.Queue<SignallingMessage,void>;
@@ -152,7 +152,7 @@ module WebRtc {
         });
 
       // New data channels from the peer.
-      this.peerCreatedChannelQueue = new Handler.Queue<DataChannel,void>();
+      this.peerOpenedChannelQueue = new Handler.Queue<DataChannel,void>();
 
       // Messages to send to the peer.
       this.signalForPeerQueue = new Handler.Queue<SignallingMessage,void>();
@@ -504,11 +504,11 @@ module WebRtc {
 
     // When a peer creates a data channel, this function is called with the
     // |RTCDataChannelEvent|. We then create the data channel wrapper and add
-    // the new |DataChannel| to the |this.peerCreatedChannelQueue| to be
+    // the new |DataChannel| to the |this.peerOpenedChannelQueue| to be
     // handled.
     private onPeerStartedDataChannel_ =
         (rtcDataChannelEvent:RTCDataChannelEvent) : void => {
-      this.peerCreatedChannelQueue.handle(
+      this.peerOpenedChannelQueue.handle(
           this.addRtcDataChannel_(rtcDataChannelEvent.channel));
     }
 

--- a/src/peerconnection/samples/chat-webpage/main.ts
+++ b/src/peerconnection/samples/chat-webpage/main.ts
@@ -26,11 +26,11 @@ var b = new WebRtc.PeerConnection(pcConfig);
 
 // Connect the two signalling channels.
 // Normally, these messages would be sent over the internet.
-a.toPeerSignalQueue.setSyncHandler((signal:WebRtc.SignallingMessage) => {
+a.signalForPeerQueue.setSyncHandler((signal:WebRtc.SignallingMessage) => {
   dbg('signalling channel A message: ' + JSON.stringify(signal));
   b.handleSignalMessage(signal);
 });
-b.toPeerSignalQueue.setSyncHandler((signal:WebRtc.SignallingMessage) => {
+b.signalForPeerQueue.setSyncHandler((signal:WebRtc.SignallingMessage) => {
   dbg('signalling channel B message: ' + JSON.stringify(signal));
   a.handleSignalMessage(signal);
 });
@@ -72,10 +72,10 @@ a.negotiateConnection().then(() => {
   }
   var chanA = a.openDataChannel('text');
   chanA.onceOpened.then(() => {
-    chanA.fromPeerDataQueue.setSyncHandler(receive.bind(null, receiveAreaA));
+    chanA.dataFromPeerQueue.setSyncHandler(receive.bind(null, receiveAreaA));
   });
   b.peerCreatedChannelQueue.setSyncHandler((chanB:WebRtc.DataChannel) => {
-    chanB.fromPeerDataQueue.setSyncHandler(receive.bind(null, receiveAreaB));
+    chanB.dataFromPeerQueue.setSyncHandler(receive.bind(null, receiveAreaB));
   });
 }, (e) => {
   dbgErr('could not negotiate peerconnection: ' + e.message);

--- a/src/peerconnection/samples/chat-webpage/main.ts
+++ b/src/peerconnection/samples/chat-webpage/main.ts
@@ -74,7 +74,7 @@ a.negotiateConnection().then(() => {
   chanA.onceOpened.then(() => {
     chanA.dataFromPeerQueue.setSyncHandler(receive.bind(null, receiveAreaA));
   });
-  b.peerCreatedChannelQueue.setSyncHandler((chanB:WebRtc.DataChannel) => {
+  b.peerOpenedChannelQueue.setSyncHandler((chanB:WebRtc.DataChannel) => {
     chanB.dataFromPeerQueue.setSyncHandler(receive.bind(null, receiveAreaB));
   });
 }, (e) => {

--- a/src/peerconnection/samples/chat2-webpage/main.ts
+++ b/src/peerconnection/samples/chat2-webpage/main.ts
@@ -40,7 +40,7 @@ interface WebrtcPcControllerScope extends ng.IScope {
   onLocalSignallingMessage :(signal:WebRtc.SignallingMessage) => void;
 }
 
-//------------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Create a new peer connection.
 var pcConfig :WebRtc.PeerConnectionConfig = {
     webrtcPcConfig: {
@@ -56,11 +56,11 @@ var pcConfig :WebRtc.PeerConnectionConfig = {
   };
 var pc :WebRtc.PeerConnection = new WebRtc.PeerConnection(pcConfig);
 
-//------------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 var webrtcPcApp = angular.module('webrtcPcApp', []);
 webrtcPcApp.controller('webrtcPcController',
     ($scope :WebrtcPcControllerScope) => {
-  //----------------------------------------------------------------------------
+  //---------------------------------------------------------------------------
   $scope.state = 'WAITING.';
   $scope.errors = [];
   $scope.connectInfo = '';
@@ -74,7 +74,7 @@ webrtcPcApp.controller('webrtcPcController',
 
   $scope.clearErrors = () => { $scope.errors = []; }
 
-  //----------------------------------------------------------------------------
+  //---------------------------------------------------------------------------
   // Promise completion callbacks
   pc.onceConnecting.then(() => {
       $scope.$apply(() => { $scope.state = 'CONNECTING...'; });
@@ -112,7 +112,7 @@ webrtcPcApp.controller('webrtcPcController',
         JSON.stringify(signal);
     });
   };
-  pc.toPeerSignalQueue.setSyncHandler($scope.onLocalSignallingMessage);
+  pc.signalForPeerQueue.setSyncHandler($scope.onLocalSignallingMessage);
 
   // Handles each line in the received 'paste' box which are messages from the
   // remote peer via the signalling channel.
@@ -164,7 +164,7 @@ webrtcPcApp.controller('webrtcPcController',
       messages: []
     };
 
-    dataChannel.fromPeerDataQueue.setSyncHandler((d:WebRtc.Data) => {
+    dataChannel.dataFromPeerQueue.setSyncHandler((d:WebRtc.Data) => {
         $scope.$apply(() => { $scope.addMessage(d, 'other'); });
       });
 

--- a/src/peerconnection/samples/chat2-webpage/main.ts
+++ b/src/peerconnection/samples/chat2-webpage/main.ts
@@ -93,7 +93,7 @@ webrtcPcApp.controller('webrtcPcController',
       $scope.$apply(() => { $scope.state = 'DISCONNECTED.'; });
     });
 
-  pc.peerCreatedChannelQueue.setSyncHandler((d:WebRtc.DataChannel) => {
+  pc.peerOpenedChannelQueue.setSyncHandler((d:WebRtc.DataChannel) => {
       $scope.$apply(() => { $scope.addDataChannel(d); });
     });
 


### PR DESCRIPTION
Tweaked the uproxypeerconnection interface so my work on socks-rtc compiles and updated samples to match.

TESTED: grunt and ran `src/coreproviders/samples/freedomchat-chromeapp/` manually, messages still flow, no console errors. 
