### PR TITLE
move webrtc typings customisations to a separate file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"

--- a/src/peerconnection/RTCPeerConnection.d.ts
+++ b/src/peerconnection/RTCPeerConnection.d.ts
@@ -1,0 +1,29 @@
+// Additions and adjustments for working with RTCPeerConnection in Chrome.
+// Tested with Chrome 36.
+
+// The type supplied to RTCPeerConnection.getStats() callbacks.
+// We can't easily override the return type defined in tsd, so note
+// that this is actually called RTCStatsResponse in Chrome:
+//   https://code.google.com/p/chromium/codesearch#chromium/src/third_party/WebKit/Source/modules/mediastream/RTCStatsResponse.h
+interface RTCStatsReport {
+  result: () => RTCStats[];
+}
+
+// This is actually called, somewhat confusingly, RTCStatsReport in Chrome:
+//   https://code.google.com/p/chromium/codesearch#chromium/src/third_party/WebKit/Source/modules/mediastream/RTCStatsReport.h
+// Since the tsd already defines a type named RTCStatsReport, we define a
+// whole new type here.
+interface RTCStats {
+  timestamp: Object; // TODO: find/define the type for DOMHiResTimeStamp
+  type: string; // RTCStatsType;
+  id: string;
+  stat?: (s:string) => string;
+  names: () => string[];
+}
+
+interface RTCPeerConnection {
+  // tsd omits the callbacks.
+  addIceCandidate(candidate: RTCIceCandidate,
+                  successCallback?: RTCVoidCallback,
+                  failureCallback?: RTCPeerConnectionErrorCallback) : void;
+}

--- a/src/peerconnection/peerconnection.ts
+++ b/src/peerconnection/peerconnection.ts
@@ -1,3 +1,4 @@
+/// <reference path='RTCPeerConnection.d.ts' />
 /// <reference path='../handler/queue.ts' />
 /// <reference path="../third_party/typings/es6-promise/es6-promise.d.ts" />
 /// <reference path='../third_party/typings/webcrypto/WebCrypto.d.ts' />

--- a/third_party/typings/webrtc/RTCPeerConnection.d.ts
+++ b/third_party/typings/webrtc/RTCPeerConnection.d.ts
@@ -212,24 +212,11 @@ declare enum RTCSignalingState {
   'closed'
 }
 
-// UPROXY NOTE:
-// A few additions have been made below to work with Chrome's
-// current implementation of RTCPeerConnection.getStats() call.
-// They are marked with // UPROXY
-
 // This is based on the current implementation of WebRtc in Chrome; the spec is
 // a little unclear on this.
 // http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCStatsReport
 interface RTCStatsReport {
-  result: () => RTCStats[] // UPROXY
-}
-
- // UPROXY
-interface RTCStats {
-  timestamp: Object; // TODO: find/define the type for DOMHiResTimeStamp
-  type: string; // RTCStatsType;
-  id: string;
-  stat?: (s:string) => string;
+  stat(id: string): string;
 }
 
 interface RTCStatsCallback {
@@ -254,9 +241,7 @@ interface RTCPeerConnection {
   signalingState: string; // RTCSignalingState; see TODO(1)
   updateIce(configuration?: RTCConfiguration,
             constraints?: RTCMediaConstraints): void;
-  addIceCandidate(candidate: RTCIceCandidate,
-                  successCallback?: RTCVoidCallback, // UPROXY
-                  failureCallback?: RTCPeerConnectionErrorCallback): void; // UPROXY
+  addIceCandidate(candidate: RTCIceCandidate): void;
   iceGatheringState: string;  // RTCIceGatheringState; see TODO(1)
   iceConnectionState: string;  // RTCIceConnectionState; see TODO(1)
   getLocalStreams(): MediaStream[];


### PR DESCRIPTION
So we can better keep track of our modifications. Also added lots of comments explaining the additions.

Tested with `freedomchat`.

Fixes:
https://github.com/uProxy/uproxy-lib/issues/37
