### PR TITLE
fixes to peer-connection (avoid renegotiations)

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -50,7 +50,7 @@ module.exports = (grunt) ->
       beautify: true
       preserveComments: (node, comment) -> comment.value.indexOf('jslint') != 0
       banner: banners.map((fileName) -> fs.readFileSync(fileName)).join('\n')
-      footer: footers.map((fileName) -> fs.readFileSync(fileName)).join('\n')
+      footer: footers.map((fileName) -> fs.readFileSync(fileName)).join('\n') + '//# sourceMappingURL=' + name + '.map'
     files: [{
       src: freedomSrc.concat(customFreedomCoreProviders).concat(files)
       dest: path.join('build/freedom/', name)
@@ -206,6 +206,7 @@ module.exports = (grunt) ->
   taskManager.add 'chat', [
     'base'
     'webrtc'
+    'logging'
     'typescript:chat'
     'copy:sampleChat'
   ]

--- a/package.json
+++ b/package.json
@@ -7,18 +7,18 @@
     "url": "https://github.com/uProxy/uproxy-lib"
   },
   "devDependencies": {
-    "es6-promise": "~1.0.0",
+    "es6-promise": "^1.0.0",
     "grunt": "~0.4.4",
-    "grunt-contrib-jasmine": "^0.6.4",
-    "grunt-contrib-clean": "^0.5.0",
-    "grunt-contrib-coffee": "^0.10.1",
-    "grunt-contrib-copy": "^0.5.0",
+    "grunt-contrib-jasmine": "~0.6.4",
+    "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-coffee": "~0.10.1",
+    "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-symlink": "~0.3.0",
     "grunt-typescript": "~0.3.7",
     "grunt-contrib-uglify": "~0.5.0",
-    "es5-shim": "~4.0.0",
+    "es5-shim": "^4.0.0",
     "freedom": "~0.5.0",
-    "freedom-for-chrome": "~0.2.3",
+    "freedom-for-chrome": "~0.3.0",
     "freedom-for-firefox": "~0.4.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "8.0.1",
+  "version": "9.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"

--- a/package.json
+++ b/package.json
@@ -8,17 +8,17 @@
   },
   "devDependencies": {
     "es6-promise": "~1.0.0",
-    "grunt": "^0.4.4",
+    "grunt": "~0.4.4",
     "grunt-contrib-jasmine": "^0.6.4",
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-coffee": "^0.10.1",
     "grunt-contrib-copy": "^0.5.0",
-    "grunt-contrib-symlink": "^0.3.0",
-    "grunt-typescript": "^0.3.7",
+    "grunt-contrib-symlink": "~0.3.0",
+    "grunt-typescript": "~0.3.7",
     "grunt-contrib-uglify": "~0.5.0",
     "es5-shim": "~4.0.0",
     "freedom": "~0.5.0",
-    "freedom-for-chrome": "~0.2.1",
+    "freedom-for-chrome": "~0.2.3",
     "freedom-for-firefox": "~0.4.1"
   },
   "scripts": {

--- a/src/freedom/coreproviders/uproxypeerconnection.d.ts
+++ b/src/freedom/coreproviders/uproxypeerconnection.d.ts
@@ -42,6 +42,7 @@ declare module freedom_UproxyPeerConnection {
     //   PeerConnection.openDataChannel().onceOpened()
     openDataChannel(channelLabel: string) : Promise<void>;
     closeDataChannel(channelLabel: string) : Promise<void>;
+    onceDataChannelOpened(channelLabel:string) : Promise<void>;
     onceDataChannelClosed(channelLabel:string) : Promise<void>;
 
     // As per PeerConnection, this fulfills once the supplied data

--- a/src/freedom/coreproviders/uproxypeerconnection.ts
+++ b/src/freedom/coreproviders/uproxypeerconnection.ts
@@ -115,6 +115,11 @@ module freedom_UproxyPeerConnection {
       this.pc_.dataChannels[channelLabel].onceClosed.then(continuation);
     }
 
+    public onceDataChannelOpened =
+        (channelLabel:string, continuation:() => void) : void => {
+      this.pc_.dataChannels[channelLabel].onceOpened.then(continuation);
+    }
+
     // Re-dispatches data channel events, such as receiving data, as
     // Freedom messages.
     private dispatchDataChannelEvents_ = (dataChannel:WebRtc.DataChannel) => {

--- a/src/freedom/interfaces/uproxypeerconnection.fdom-interface.ts
+++ b/src/freedom/interfaces/uproxypeerconnection.fdom-interface.ts
@@ -69,6 +69,11 @@ fdom.apis.set('core.uproxypeerconnection', {
     value: ['string']
   },
 
+  'onceDataChannelOpened': {
+    type: 'method',
+    value: ['string']
+  },
+
   'onceDataChannelClosed': {
     type: 'method',
     value: ['string']

--- a/src/webrtc/datachannel.d.ts
+++ b/src/webrtc/datachannel.d.ts
@@ -38,5 +38,7 @@ declare module WebRtc {
     // Closes this data channel.
     // A channel cannot be re-opened once this has been called.
     public close :() => void;
+
+    public toString :() => string;
   }
 }

--- a/src/webrtc/datachannel.d.ts
+++ b/src/webrtc/datachannel.d.ts
@@ -8,7 +8,7 @@ declare module WebRtc {
     // Only one of these should be specified.
     // TODO: use union type once it is supported in TypeScript.
     str    ?:string;
-    buffer ?:Uint8Array;
+    buffer ?:ArrayBuffer;
   }
 
   class DataChannel {

--- a/src/webrtc/datachannel.ts
+++ b/src/webrtc/datachannel.ts
@@ -8,6 +8,12 @@
 // platform compatibility library webrtc-adaptor.js (from:
 // https://code.google.com/p/webrtc/source/browse/stable/samples/js/base/adapter.js)
 
+// TODO: once typescript with https://github.com/Microsoft/TypeScript/issues/310
+// is released, this can be removed.
+interface ArrayBuffer {
+  slice :(start?:number, end?:number) => ArrayBuffer;
+}
+
 module WebRtc {
 
   // Messages are limited to a 16KB length by SCTP; we use 15k for safety.
@@ -30,7 +36,7 @@ module WebRtc {
   // connection.
   export interface Data {
     str ?:string;
-    buffer ?:Uint8Array;
+    buffer ?:ArrayBuffer;
     // TODO: add when supported by WebRtc in Chrome and FF.
     // https://code.google.com/p/webrtc/issues/detail?id=2276
     //
@@ -42,7 +48,7 @@ module WebRtc {
     str :string;
   }
   interface BufferData {
-    buffer :Uint8Array;
+    buffer :ArrayBuffer;
   }
 
   var log :Logging.Log = new Logging.Log('DataChannel');
@@ -175,14 +181,13 @@ module WebRtc {
       while(startByte < data.buffer.byteLength) {
         endByte = Math.min(startByte + CHUNK_SIZE, data.buffer.byteLength);
         promises.push(this.toPeerDataQueue_.handle(
-            {buffer: data.buffer.subarray(startByte, endByte)}));
+            {buffer: data.buffer.slice(startByte, endByte)}));
         startByte += CHUNK_SIZE;
       }
 
       // CONSIDER: can we change the interface to support not having the dummy
       // extra return at the end?
-      return Promise.all(promises)
-          .then<void>((_) => { return; });
+      return Promise.all(promises).then(() => { return; });
     }
 
     // Assumes data is chunked.

--- a/src/webrtc/datachannel.ts
+++ b/src/webrtc/datachannel.ts
@@ -45,6 +45,8 @@ module WebRtc {
     buffer :Uint8Array;
   }
 
+  var log :Logging.Log = new Logging.Log('DataChannel');
+
   // Wrapper for a WebRtc Data Channels:
   // http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel
   //
@@ -58,10 +60,11 @@ module WebRtc {
     private toPeerDataQueue_        :Handler.Queue<Data,void>;
 
     public onceOpened      :Promise<void>;
-    public onceClosed       :Promise<void>;
+    public onceClosed      :Promise<void>;
 
-    private label_ :string;
-    private wasOpenned_     :boolean;
+    private label_         :string;
+
+    private opennedSuccessfully_ :boolean;
     private rejectOpened_  :(e:Error) => void;
 
     public getLabel = () : string => {
@@ -94,17 +97,21 @@ module WebRtc {
           this.rtcDataChannel_.onclose = (e:Event) => { F(); };
         });
       this.rtcDataChannel_.onmessage = this.onDataFromPeer_;
-      this.rtcDataChannel_.onerror = console.error;
-
-      // Make sure to reject the onceOpened promise if state went from
-      // |connecting| to |close|.
+      this.rtcDataChannel_.onerror = (e:Event) => {
+        log.error('rtcDataChannel_.onerror: ' + this.label_ + ': ' + e.toString);
+      };
       this.onceOpened.then(() => {
-        this.wasOpenned_ = true;
+        this.opennedSuccessfully_ = true;
         this.toPeerDataQueue_.setHandler(this.handleSendDataToPeer_);
       });
       this.onceClosed.then(() => {
-          if(!this.wasOpenned_) { this.rejectOpened_(new Error(
-              'Failed to open; closed while trying to open.')); }
+          if(!this.opennedSuccessfully_) {
+            // Make sure to reject the onceOpened promise if state went from
+            // |connecting| to |close|.
+            this.rejectOpened_(new Error(
+                'Failed to open; closed while trying to open.'));
+          }
+          this.opennedSuccessfully_ = false;
         });
     }
 
@@ -116,7 +123,7 @@ module WebRtc {
       } else if (typeof messageEvent.data === 'ArrayBuffer') {
         this.dataFromPeerQueue.handle({buffer: messageEvent.data});
       } else {
-        console.error('Unexpected data from peer that has type: ' +
+        log.error('Unexpected data from peer that has type: ' +
             JSON.stringify(messageEvent));
       }
     }
@@ -192,8 +199,9 @@ module WebRtc {
       return Promise.resolve<void>();
     }
 
-    // TODO: make this timeout adaptive so that we keep the buffer as full
-    // as we can without wasting timeout callbacks.
+    // TODO: make this timeout adaptive so that we keep the buffer as full as we
+    // can without wasting timeout callbacks. When DataChannels correctly has a
+    // callback for buffering, we don't need to do this anymore.
     private conjestionControlSendHandler = () : void => {
       if(this.rtcDataChannel_.bufferedAmount + CHUNK_SIZE > PC_QUEUE_LIMIT) {
         if(this.toPeerDataQueue_.isHandling()) {
@@ -209,6 +217,12 @@ module WebRtc {
 
     public close = () : void => {
       this.rtcDataChannel_.close();
+    }
+
+    public toString = () : string => {
+      var s = this.getLabel() + ': opennedSuccessfully_=' +
+        this.opennedSuccessfully_ + '; state=' + this.getState();
+      return s;
     }
   }  // class DataChannel
 }  // module

--- a/src/webrtc/peerconnection.ts
+++ b/src/webrtc/peerconnection.ts
@@ -535,8 +535,10 @@ module WebRtc {
 
     // Open a new data channel with the peer.
     public openDataChannel = (channelLabel:string,
-                              options:RTCDataChannelInit={})
+                              options?:RTCDataChannelInit)
         : DataChannel => {
+      log.debug(this.peerName + ': ' + 'openDataChannel: ' + channelLabel +
+          '; options=' + JSON.stringify(options));
       var rtcDataChannel = this.pc_.createDataChannel(channelLabel, options);
 
       // Firefox does not fire the |'negotiationneeded'| event, so we need to
@@ -558,6 +560,8 @@ module WebRtc {
     // handled.
     private onPeerStartedDataChannel_ =
         (rtcDataChannelEvent:RTCDataChannelEvent) : void => {
+      log.debug(this.peerName + ': ' + 'onPeerStartedDataChannel: ' +
+          rtcDataChannelEvent.channel);
       this.peerOpenedChannelQueue.handle(
           this.addRtcDataChannel_(rtcDataChannelEvent.channel));
     }

--- a/src/webrtc/samples/chat-webpage/main.ts
+++ b/src/webrtc/samples/chat-webpage/main.ts
@@ -33,7 +33,8 @@ function setupLoggingPeerConnection(name:string) : WebRtc.PeerConnection {
         endpoints.local.address + ':' + endpoints.local.port +
         ' (' + WebRtc.CandidateType[endpoints.localType] + ') <-> ' +
         endpoints.remote.address + ':' + endpoints.remote.port +
-        ' (' + WebRtc.CandidateType[endpoints.remoteType] + ')');
+        ' (' + WebRtc.CandidateType[endpoints.remoteType] + ')\n' +
+        pc.toString());
   });
   pc.onceConnecting.then(() => {
     log.info(name + ': onceConnecting: ' + pc.toString());
@@ -65,13 +66,12 @@ var b :WebRtc.PeerConnection = setupLoggingPeerConnection('b');
 // Connect the two signalling channels. Normally, these messages would be sent
 // over the internet.
 a.signalForPeerQueue.setSyncHandler((signal:WebRtc.SignallingMessage) => {
-    log.info('a: sent signal (to b): ' + JSON.stringify(signal));
     b.handleSignalMessage(signal);
   });
 b.signalForPeerQueue.setSyncHandler((signal:WebRtc.SignallingMessage) => {
-  log.info('b: sent signal (to a): ' + JSON.stringify(signal));
   a.handleSignalMessage(signal);
 });
+
 
 // Have a negotiate a peerconnection. Once negotiated, enable the UI and add
 // send/receive handlers.


### PR DESCRIPTION
- Moved to using better logging for datachannel.ts
- Added sourcemap for freedom
- Made peer-connection avoid bad renegotiation events (now starts negotiation by opening a data channel, so that the SDP headers always include data channels)
- Cleaned up chat sample, and freedomchat sample.
- Added catch statements for errors
- Set options for data channel opening to optional. 
- Now using just ArrayBuffers for webrtc data because freedom/chrome/node/... don't correctly support passing arraybuffer views to webworkers.

TESTED: 
- grunt 
- manually ran chat, chat2, and freedomchat
