### PR TITLE
Small fixes for: freedom logging; secure in freedom tcp sockets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"

--- a/src/freedom/samples/freedomchat-chromeapp/main.html
+++ b/src/freedom/samples/freedomchat-chromeapp/main.html
@@ -30,7 +30,7 @@
     {
       // This is useful for debugging.
       //
-      "debug": true
+      "debug": "debug"
 
       // This makes modules run in iFrames instead of WebWorkers. You get
       // syntax error warnings from iFrames where WebWorker's silently die.
@@ -41,7 +41,7 @@
   <script src='lib/freedom/freedom-for-webpages-for-uproxy.js'
           data-manifest='freedom-module.json'>
   {
-    "debug": false
+    "debug": "log"
   }
   </script>
   <script src='main.js'></script>

--- a/src/freedom/typings/tcp-socket.d.ts
+++ b/src/freedom/typings/tcp-socket.d.ts
@@ -37,6 +37,7 @@
     interface Socket {
       listen(address:string, port:number) : Promise<void>;
       connect(hostname:string, port:number) : Promise<void>;
+      secure() : Promise<void>;
       write(data:ArrayBuffer) : Promise<WriteInfo>;
       getInfo() : Promise<SocketInfo>;
       close() : Promise<void>;


### PR DESCRIPTION
This adds this change https://github.com/uProxy/uproxy-lib/pull/42 (which it looks like we forgot to merge at the time), and includes a small patch for new freedom logging. 

TESTED: grunt
