### PR TITLE
add mediaconstraints to createoffer

### DIFF
--- a/src/webrtc/peerconnection.ts
+++ b/src/webrtc/peerconnection.ts
@@ -239,10 +239,14 @@ module WebRtc {
     // description that should be set as the local description and sent to the
     // peer.
     private createOffer_ = () : Promise<RTCSessionDescription> => {
-      return new Promise((F,R) => { this.pc_.createOffer(F, R); });
+      return new Promise((F,R) => {
+        this.pc_.createOffer(F, R, this.config_.webrtcMediaConstraints);
+      });
     }
     private createAnswer_ = () : Promise<RTCSessionDescription> => {
-      return new Promise((F,R) => { this.pc_.createAnswer(F, R); });
+      return new Promise((F,R) => {
+        this.pc_.createAnswer(F, R, this.config_.webrtcMediaConstraints);
+      });
     }
     // Setting the local description will be followed by sending the SDP message
     // to the peer, so we return the description value here.


### PR DESCRIPTION
So, I was playing around with offerToReceiveAudio as Ben suggested.

It does indeed improve what we see on `chrome://webrtc-internals/`: `Conn-audio-1-0` is replaced with `Conn-data-1-0`. No functional difference that I can see but it does seem to be cleaner, and the SDP offers and answers are significantly shorter, too.

It seems you need to supply the constraints to `createOffer` and `createAnswer` which is a bit annoying...not high priority but curious what you think of this approach.
