### PR TITLE
Fixes handling of ArrayBuffers in send over data channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,4 @@ language: node_js
 node_js:
  - "0.11"
  - "0.10"
-before_script:
- - npm install -g grunt-cli
+before_install: npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -1,11 +1,19 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "9.1.1",
+  "version": "10.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"
   },
+  "bugs": {
+    "url": "https://github.com/uProxy/uproxy-networking/issues",
+    "email": "uproxy-eng@googlegroups.com"
+  },
+  "licenses": [ {
+    "type": "Apache-2.0",
+    "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+  } ],
   "devDependencies": {
     "es6-promise": "^1.0.0",
     "arraybuffer-slice": "~0.1.2",
@@ -19,10 +27,11 @@
     "grunt-contrib-uglify": "~0.5.0",
     "es5-shim": "^4.0.0",
     "freedom": "~0.5.0",
-    "freedom-for-chrome": "~0.3.1",
+    "freedom-for-chrome": "~0.3.2",
     "freedom-for-firefox": "~0.4.1"
   },
   "scripts": {
-    "test": "grunt --verbose"
+    "test": "grunt test",
+    "prepublish": "grunt test"
   }
 }

--- a/src/freedom/samples/freedomchat-chromeapp/main.html
+++ b/src/freedom/samples/freedomchat-chromeapp/main.html
@@ -2,6 +2,7 @@
 <head>
   <title>PeerConnection chat client</title>
   <!-- Dependencies for freedom-for-*-for-uproxy -->
+  <script src='lib/arraybuffers/arraybuffers.js'></script>
   <script src='lib/handler/queue.js'></script>
   <script src='lib/logging/logging.js'></script>
   <script src='lib/webrtc/third_party/adapter.js'></script>

--- a/src/webrtc/datachannel.d.ts
+++ b/src/webrtc/datachannel.d.ts
@@ -1,4 +1,4 @@
-/// <reference path="../handler/queue.ts" />
+/// <reference path="../handler/queue.d.ts" />
 /// <reference path="../third_party/typings/es6-promise/es6-promise.d.ts" />
 /// <reference path="../third_party/typings/webrtc/RTCPeerConnection.d.ts" />
 

--- a/src/webrtc/peerconnection.d.ts
+++ b/src/webrtc/peerconnection.d.ts
@@ -4,7 +4,7 @@
 /// <reference path="../third_party/typings/webcrypto/WebCrypto.d.ts" />
 /// <reference path="../third_party/typings/webrtc/RTCPeerConnection.d.ts" />
 
-/// <reference path="../handler/queue.ts" />
+/// <reference path="../handler/queue.d.ts" />
 
 declare module WebRtc {
 

--- a/src/webrtc/peerconnection.ts
+++ b/src/webrtc/peerconnection.ts
@@ -1,5 +1,5 @@
 /// <reference path='RTCPeerConnection.d.ts' />
-/// <reference path='../handler/queue.ts' />
+/// <reference path='../handler/queue.d.ts' />
 /// <reference path="../third_party/typings/es6-promise/es6-promise.d.ts" />
 /// <reference path='../third_party/typings/webcrypto/WebCrypto.d.ts' />
 /// <reference path='../third_party/typings/webrtc/RTCPeerConnection.d.ts' />

--- a/src/webrtc/samples/chat-webpage/main.html
+++ b/src/webrtc/samples/chat-webpage/main.html
@@ -20,6 +20,7 @@
     <button id="sendButtonB">Send</button>
   </div>
 
+  <script src='lib/arraybuffers/arraybuffers.js'></script>
   <script src='lib/handler/queue.js'></script>
   <script src='lib/logging/logging.js'></script>
   <script src='lib/webrtc/third_party/adapter.js'></script>

--- a/src/webrtc/samples/chat-webpage/main.ts
+++ b/src/webrtc/samples/chat-webpage/main.ts
@@ -13,7 +13,7 @@ var receiveAreaB = <HTMLInputElement>document.getElementById("receiveAreaB");
 var log :Logging.Log = new Logging.Log('main.ts');
 
 // Create a peer connection with logging for all its actions.
-function setupLoggingPeerConnection(name:string) : WebRtc.PeerConnection {
+function setupLoggingPeerConnection(name:string, receiveArea:HTMLInputElement) : WebRtc.PeerConnection {
   var pcConfig :WebRtc.PeerConnectionConfig = {
     webrtcPcConfig: {
       iceServers: [{url: 'stun:stun.l.google.com:19302'},
@@ -43,25 +43,32 @@ function setupLoggingPeerConnection(name:string) : WebRtc.PeerConnection {
     log.info(name + ': onceDisconnected: ' + pc.toString());
   });
   pc.peerOpenedChannelQueue.setSyncHandler((d:WebRtc.DataChannel) => {
+    log.info(name + ': peerOpenedChannelQueue: ' +
+          d.toString());
     d.onceOpened.then(() => {
-      log.info(name + ': ' + d.getLabel() + ': onceOpened: ' +
+      log.info(name + ': onceOpened: ' +
           d.toString());
     });
     d.onceClosed.then(() => {
-      log.info(name + ': ' + d.getLabel() + ': onceClosed: ' +
+      log.info(name + ': onceClosed: ' +
           d.toString());
     });
     d.dataFromPeerQueue.setSyncHandler((data:WebRtc.Data) => {
-      log.info(name + ': ' + d.getLabel() + ': dataFromPeer: ' +
-          JSON.stringify(data));
+      log.info(name + ': dataFromPeer: ' + JSON.stringify(data));
+      // Handle messages received on the datachannel(s).
+      // The message is forwarded to the UI.
+      // TODO: only the first message sent over the data channel is received
+      if(receiveArea) {
+        receiveArea.value = JSON.stringify(data);
+      }
     });
   });
   return pc;
 }
 
 //------------------------------------------------------------------------------
-var a :WebRtc.PeerConnection = setupLoggingPeerConnection('a');
-var b :WebRtc.PeerConnection = setupLoggingPeerConnection('b');
+var a :WebRtc.PeerConnection = setupLoggingPeerConnection('a', receiveAreaA);
+var b :WebRtc.PeerConnection = setupLoggingPeerConnection('b', receiveAreaB);
 
 // Connect the two signalling channels. Normally, these messages would be sent
 // over the internet.
@@ -71,7 +78,6 @@ a.signalForPeerQueue.setSyncHandler((signal:WebRtc.SignallingMessage) => {
 b.signalForPeerQueue.setSyncHandler((signal:WebRtc.SignallingMessage) => {
   a.handleSignalMessage(signal);
 });
-
 
 // Have a negotiate a peerconnection. Once negotiated, enable the UI and add
 // send/receive handlers.
@@ -92,19 +98,7 @@ a.negotiateConnection().then(() => {
   sendButtonA.onclick = send.bind(null, a, sendAreaA);
   sendButtonB.onclick = send.bind(null, b, sendAreaB);
 
-  // Handle messages received on the datachannel(s).
-  // The message is forwarded to the UI.
-  // TODO: only the first message sent over the data channel is received
-  function receive(textArea:HTMLInputElement, d:WebRtc.Data) {
-    textArea.value = d.str;
-  }
   var chanA = a.openDataChannel('text');
-  chanA.onceOpened.then(() => {
-    chanA.dataFromPeerQueue.setSyncHandler(receive.bind(null, receiveAreaA));
-  });
-  b.peerOpenedChannelQueue.setSyncHandler((chanB:WebRtc.DataChannel) => {
-    chanB.dataFromPeerQueue.setSyncHandler(receive.bind(null, receiveAreaB));
-  });
 }, (e) => {
   log.error('could not negotiate peerconnection: ' + e.message);
 });

--- a/src/webrtc/samples/chat2-webpage/main.html
+++ b/src/webrtc/samples/chat2-webpage/main.html
@@ -2,6 +2,7 @@
 <head>
   <title>Peer Connection Sample Code</title>
   <script src='lib/logging/logging.js'></script>
+  <script src='lib/arraybuffers/arraybuffers.js'></script>
   <script src='lib/handler/queue.js'></script>
   <script src='lib/third_party/angular/angular-1.3.0-beta15.min.js'></script>
   <script src='lib/webrtc/third_party/adapter.js'></script>


### PR DESCRIPTION
- Fixed bug where I'd used typeof when I should have used instanceof which made data channels not able to receive arraybuffers.
- changed dependencies of webrtc to use the .d.ts files (faster, less redundant compilation)
- Use chunking from array buffers, simplifying data channel code. 
- Simplify sample code little & standardize

TESTED: 

```
grunt
python -m SimpleHTTPServer
```

Then open `build/freedom/samples/freedomchat-chromeapp/main.html` in Chrome, then type the following into the console: 

```
var dc = a.openDataChannel('data');
var p = dc.send({buffer: new ArrayBuffer(10)});
```

Observe that no error, and that the chat window shows `{buffer: {}` which is the pretty print of the ArrayBuffer.
