### PR TITLE
Better error handling for peer connection failures

### DIFF
--- a/src/freedom/coreproviders/uproxylogging.ts
+++ b/src/freedom/coreproviders/uproxylogging.ts
@@ -6,7 +6,8 @@ module Freedom_UproxyLogging {
   export class LogManager {
     // Dummy consturctor because freedom needs one.
     constructor(
-      private module_:any,  // TODO: fix `any` type.
+      // TODO: fix `any` type: https://github.com/uProxy/uproxy/issues/353
+      private module_:any,
       // dispatchEvent_ is never used, hense void eventData.
       private dispatchEvent_:(eventType:string, eventData:void) => void) {}
     //

--- a/src/freedom/coreproviders/uproxypeerconnection.ts
+++ b/src/freedom/coreproviders/uproxypeerconnection.ts
@@ -155,10 +155,16 @@ module freedom_UproxyPeerConnection {
                    data :WebRtc.Data,
                    continuation :() => void) : void => {
       // TODO: propagate errors
+      if(!(channelLabel in this.pc_.dataChannels)) {
+        this.log_.warn('No such channel label (maybe internal error?): ' + channelLabel);
+        continuation();
+        return
+      }
+
       this.pc_.dataChannels[channelLabel].send(data)
         .then(continuation)
         .catch((e:Error) => {
-          this.log_.error(e.toString());
+          this.log_.warn(e.toString());
           // TODO: propagate errors
         });
     }

--- a/src/freedom/coreproviders/uproxypeerconnection.ts
+++ b/src/freedom/coreproviders/uproxypeerconnection.ts
@@ -16,9 +16,8 @@ module freedom_UproxyPeerConnection {
     private log_ :Logging.Log;
 
     constructor(
-        // TODO: fix `any` type.
+        // TODO: fix `any` type: https://github.com/uProxy/uproxy/issues/353
         private module_:any,
-        // TODO: see comment in .d.ts: use real type not any.
         private dispatchEvent_:(eventType:string, eventData:any) => void,
         config:WebRtc.PeerConnectionConfig) {
 
@@ -59,12 +58,11 @@ module freedom_UproxyPeerConnection {
     public negotiateConnection =
         (continuation:(endpoints:WebRtc.ConnectionAddresses) => void)
         : void => {
-      // TODO: propagate errors
       this.pc_.negotiateConnection()
         .then(continuation)
         .catch((e:Error) => {
           this.log_.error(e.toString());
-          // TODO: propagate errors
+          // TODO: propagate error. https://github.com/uProxy/uproxy/issues/354
         });
     }
 
@@ -74,7 +72,7 @@ module freedom_UproxyPeerConnection {
         .then(continuation)
         .catch((e:Error) => {
           this.log_.error(e.toString());
-          // TODO: propagate errors
+          // TODO: propagate error. https://github.com/uProxy/uproxy/issues/354
         });
     }
 
@@ -85,7 +83,7 @@ module freedom_UproxyPeerConnection {
         .then(continuation)
         .catch((e:Error) => {
           this.log_.error(e.toString());
-          // TODO: propagate errors
+          // TODO: propagate error. https://github.com/uProxy/uproxy/issues/354
         });
     }
 
@@ -94,7 +92,7 @@ module freedom_UproxyPeerConnection {
         .then(continuation)
         .catch((e:Error) => {
           this.log_.error(e.toString());
-          // TODO: propagate errors
+          // TODO: propagate error. https://github.com/uProxy/uproxy/issues/354
         });
     }
 
@@ -103,7 +101,7 @@ module freedom_UproxyPeerConnection {
         .then(continuation)
         .catch((e:Error) => {
           this.log_.error(e.toString());
-          // TODO: propagate errors
+          // TODO: propagate error. https://github.com/uProxy/uproxy/issues/354
         });
     }
 
@@ -140,7 +138,7 @@ module freedom_UproxyPeerConnection {
         })
         .catch((e:Error) => {
           this.log_.error(e.toString());
-          // TODO: propagate errors
+          // TODO: propagate error. https://github.com/uProxy/uproxy/issues/354
         });
     }
 
@@ -154,9 +152,9 @@ module freedom_UproxyPeerConnection {
     public send = (channelLabel :string,
                    data :WebRtc.Data,
                    continuation :() => void) : void => {
-      // TODO: propagate errors
       if(!(channelLabel in this.pc_.dataChannels)) {
         this.log_.warn('No such channel label (maybe internal error?): ' + channelLabel);
+        // TODO: propagate error. https://github.com/uProxy/uproxy/issues/354
         continuation();
         return
       }
@@ -165,7 +163,7 @@ module freedom_UproxyPeerConnection {
         .then(continuation)
         .catch((e:Error) => {
           this.log_.warn(e.toString());
-          // TODO: propagate errors
+          // TODO: propagate error. https://github.com/uProxy/uproxy/issues/354
         });
     }
   }  // class FreedomImpl

--- a/src/webrtc/datachannel.ts
+++ b/src/webrtc/datachannel.ts
@@ -183,13 +183,20 @@ module WebRtc {
 
     // Assumes data is chunked.
     private handleSendDataToPeer_ = (data:Data) : Promise<void> => {
-      if(data.str) {
-        this.rtcDataChannel_.send(data.str);
-      } else if(data.buffer) {
-        this.rtcDataChannel_.send(data.buffer);
-      } else {
+      try {
+        if(data.str) {
+          this.rtcDataChannel_.send(data.str);
+        } else if(data.buffer) {
+          this.rtcDataChannel_.send(data.buffer);
+        } else {
+          return Promise.reject(new Error(
+              'Bad data: ' + JSON.stringify(data)));
+        }
+      // Can raise NetworkError if channel died, for example.
+      } catch (e) {
+        log.debug('Error in send' + e.toString());
         return Promise.reject(new Error(
-            'Bad data: ' + JSON.stringify(data)));
+              'Error in send: ' + JSON.stringify(e)));
       }
       this.conjestionControlSendHandler();
       return Promise.resolve<void>();

--- a/src/webrtc/datachannel.ts
+++ b/src/webrtc/datachannel.ts
@@ -189,6 +189,8 @@ module WebRtc {
         } else if(data.buffer) {
           this.rtcDataChannel_.send(data.buffer);
         } else {
+          // Data is good when it meets the type expected of the Data. If type-
+          // saftey is ensured at compile time, this should never happen.
           return Promise.reject(new Error(
               'Bad data: ' + JSON.stringify(data)));
         }

--- a/src/webrtc/datachannel.ts
+++ b/src/webrtc/datachannel.ts
@@ -198,7 +198,7 @@ module WebRtc {
       } catch (e) {
         log.debug('Error in send' + e.toString());
         return Promise.reject(new Error(
-              'Error in send: ' + JSON.stringify(e)));
+            'Error in send: ' + JSON.stringify(e)));
       }
       this.conjestionControlSendHandler();
       return Promise.resolve<void>();

--- a/src/webrtc/peerconnection.ts
+++ b/src/webrtc/peerconnection.ts
@@ -89,6 +89,10 @@ module WebRtc {
   // Logger for this module.
   var log :Logging.Log = new Logging.Log('PeerConnection');
 
+  // Global listing of active peer connections. Helpful for debugging when you
+  // are in Freedom.
+  export var peerConnections :{ [name:string] : PeerConnection } = {};
+
   // A wrapper for peer-connection and it's associated data channels.
   // The most important diagram is this one:
   // http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCSignalingState
@@ -185,6 +189,15 @@ module WebRtc {
       this.onceDisconnected = new Promise<void>((F,R) => {
           this.fulfillDisconnected_ = F;
         });
+
+      // Once connected, add to global listing. Helpful for debugging.
+      this.onceConnected.then(() => {
+        peerConnections[this.peerName] = this;
+      });
+      // Once disconnected, remove from global listing.
+      this.onceDisconnected.then(() => {
+        delete peerConnections[this.peerName];
+      });
 
       // New data channels from the peer.
       this.peerOpenedChannelQueue = new Handler.Queue<DataChannel,void>();


### PR DESCRIPTION
NOTE: this builds on pull requests #52 #53
- Enables peer-connections to be debugged from the core runtime environment.
- Improves error catching/handling 
  - data channel send can fail if the remote side closes the data channel while we try to send) 
  - data channels might be removed; so a freedom peer connection send needs to check the channel exists first. 
