### PR TITLE
common-grunt-task spec declaration checks now ignore samples

### DIFF
--- a/tools/common-grunt-rules.js
+++ b/tools/common-grunt-rules.js
@@ -8,8 +8,8 @@ var exports;
         return {
             src: [
                 'build/typescript-src/' + name + '/**/*.ts',
-                '!build/typescript-src/' + name + '/samples/**/*.ts',
-                '!build/typescript-src/' + name + '/**/*.d.ts'],
+                '!**/*.d.ts',
+                '!build/typescript-src/' + name + '/**/samples/**'],
             dest: 'build/',
             options: {
                 basePath: 'build/typescript-src/',
@@ -28,7 +28,8 @@ var exports;
         return {
             src: [
                 'build/typescript-src/' + name + '/**/*.spec.ts',
-                'build/typescript-src/' + name + '/**/*.d.ts'],
+                'build/typescript-src/' + name + '/**/*.d.ts',
+                '!build/typescript-src/' + name + '/**/samples/**/*'],
             dest: 'build/',
             options: {
                 basePath: 'build/typescript-src/',

--- a/tools/common-grunt-rules.js
+++ b/tools/common-grunt-rules.js
@@ -29,7 +29,7 @@ var exports;
             src: [
                 'build/typescript-src/' + name + '/**/*.spec.ts',
                 'build/typescript-src/' + name + '/**/*.d.ts',
-                '!build/typescript-src/' + name + '/**/samples/**/*'],
+                '!build/typescript-src/' + name + '/**/samples/**'],
             dest: 'build/',
             options: {
                 basePath: 'build/typescript-src/',

--- a/tools/common-grunt-rules.ts
+++ b/tools/common-grunt-rules.ts
@@ -6,8 +6,8 @@ module exports {
   export function typescriptSrc(name:string) {
     return {
       src: ['build/typescript-src/' + name + '/**/*.ts',
-            '!build/typescript-src/' + name + '/samples/**/*.ts',
-            '!build/typescript-src/' + name + '/**/*.d.ts'],
+            '!**/*.d.ts',
+            '!build/typescript-src/' + name + '/**/samples/**'],
       dest: 'build/',
       options: {
         basePath: 'build/typescript-src/',
@@ -24,7 +24,8 @@ module exports {
   export function typescriptSpecDecl(name:string) {
     return {
       src: ['build/typescript-src/' + name + '/**/*.spec.ts',
-            'build/typescript-src/' + name + '/**/*.d.ts'],
+            'build/typescript-src/' + name + '/**/*.d.ts',
+            '!build/typescript-src/' + name + '/**/samples/**/*'],
       dest: 'build/',
       options: {
         basePath: 'build/typescript-src/',

--- a/tools/common-grunt-rules.ts
+++ b/tools/common-grunt-rules.ts
@@ -25,7 +25,7 @@ module exports {
     return {
       src: ['build/typescript-src/' + name + '/**/*.spec.ts',
             'build/typescript-src/' + name + '/**/*.d.ts',
-            '!build/typescript-src/' + name + '/**/samples/**/*'],
+            '!build/typescript-src/' + name + '/**/samples/**'],
       dest: 'build/',
       options: {
         basePath: 'build/typescript-src/',


### PR DESCRIPTION
- The typescriptSpecDecl rule ignores sample directories
- Standardized the ignore of .d.ts and samples. 
