### PR TITLE
bump version for republishing npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "11.0.1",
+  "version": "11.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"


### PR DESCRIPTION
The NPM for 11.0.1 had no `build/` folder :-/
