### PR TITLE
do not automatically generate .d.ts files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"

--- a/tools/common-grunt-rules.js
+++ b/tools/common-grunt-rules.js
@@ -17,6 +17,7 @@ var exports;
                 comments: false,
                 noImplicitAny: true,
                 sourceMap: true,
+                declaration: false,
                 fast: 'always'
             }
         };
@@ -38,7 +39,7 @@ var exports;
                 comments: false,
                 noImplicitAny: true,
                 sourceMap: true,
-                declaration: true,
+                declaration: false,
                 fast: 'always'
             }
         };

--- a/tools/common-grunt-rules.ts
+++ b/tools/common-grunt-rules.ts
@@ -17,6 +17,7 @@ module exports {
         comments: false,
         noImplicitAny: true,
         sourceMap: true,
+        declaration: false,
         fast: 'always',
       }
     };
@@ -37,7 +38,7 @@ module exports {
         comments: false,
         noImplicitAny: true,
         sourceMap: true,
-        declaration: true,
+        declaration: false,
         fast: 'always',
       }
     };


### PR DESCRIPTION
They will obliterate manually written `.d.ts` files. Dunno how this slipped through.

Quick fix for:
https://github.com/uProxy/uproxy-lib/pull/72
