### PR TITLE
remove circular dependency from webrtc target

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -263,7 +263,6 @@ module.exports = (grunt) ->
     'logging'
     'crypto'
     'handler'
-    'uproxyCoreEnv'
     'base'
     'ts:webrtc'
     'copy:webrtc'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "12.0.1",
+  "version": "12.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"


### PR DESCRIPTION
It really messes up `uproxy-core-env.js`.

Another quick fix for:
https://github.com/uProxy/uproxy-lib/pull/72

I filed this to help prevent it happening again:
https://github.com/uProxy/uproxy/issues/429
