### PR TITLE
make the logging wrapper class output to core.console

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -82,7 +82,13 @@ module.exports = (grunt) ->
       handler: Rule.jasmineSpec 'handler'
       taskmanager: Rule.jasmineSpec 'taskmanager'
       arraybuffers: Rule.jasmineSpec 'arraybuffers'
-      logging: Rule.jasmineSpec 'logging'
+      logging:
+        src: [
+          'build/logging/mocks.js'
+          'build/logging/logging.js'
+        ]
+        options:
+          specs: 'build/logging/*.spec.js'
 
     clean: ['build/', 'dist/', '.tscache/']
 
@@ -157,6 +163,7 @@ module.exports = (grunt) ->
     'base'
     'logging'
     'freedom'
+    'webrtc'
     'ts:simpleFreedomChat'
     'copy:simpleFreedomChat'
     'copy:simpleFreedomChatLib'

--- a/src/freedom/typings/console.d.ts
+++ b/src/freedom/typings/console.d.ts
@@ -1,0 +1,15 @@
+// Typescript file for core.console in:
+// https://github.com/freedomjs/freedom/blob/master/interface/core.console.json
+/// <reference path="../../third_party/typings/es6-promise/es6-promise.d.ts" />
+/// <reference path='freedom.d.ts' />
+
+declare module freedom_Console {
+  class Console {
+    constructor();
+    log(source:string, message:string) : Promise<void>;
+    debug(source:string, message:string) : Promise<void>;
+    info(source:string, message:string) : Promise<void>;
+    warn(source:string, message:string) : Promise<void>;
+    error(source:string, message:string) : Promise<void>;
+  }
+}

--- a/src/logging/logging.spec.ts
+++ b/src/logging/logging.spec.ts
@@ -19,15 +19,15 @@ describe("logger from core environment", () => {
 
   it('format string', () => {
     expect(Logging.formatMessage(message1))
-        .toMatch(/\*\[tag\]\(.*\) D: simple string/);
+        .toMatch(/D \[.*\] simple string/);
     expect(Logging.formatMessage(message2))
-        .toMatch(/\*\[tag\]\(.*\) D: simple string/);
+        .toMatch(/D \[.*\] simple string/);
     expect(Logging.formatMessage(message3))
-        .toMatch(/\*\[test-module\]\(.*\) I: second string/);
+        .toMatch(/I \[.*\] second string/);
     expect(Logging.formatMessage(message4))
-        .toMatch(/\*\[test\]\(.*\) W: Bob pinged Alice with id=123456/);
+        .toMatch(/W \[.*\] Bob pinged Alice with id=123456/);
     expect(Logging.formatMessage(message5))
-        .toMatch(/\*\[test\]\(.*\) E: Bob pinged Alice with id=123456/);
+        .toMatch(/E \[.*\] Bob pinged Alice with id=123456/);
   });
 
   it('grab logs', () => {
@@ -36,7 +36,7 @@ describe("logger from core environment", () => {
     log2.info('second string');
     log2.error('third string');
     expect(Logging.getLogs().join('\n')).toMatch(
-      /\*\[tag2\]\(.*\) E: third string/);
+      /E \[.*\] third string/);
 
     // set to log all messages.
     Logging.clearLogs();
@@ -45,7 +45,7 @@ describe("logger from core environment", () => {
     log2.info('second string');
     log2.error('third string');
     expect(Logging.getLogs().join('\n')).toMatch(
-      /\*\[tag1\]\(.*\) D: simple string\n\*\[tag2\]\(.*\) I: second string\n\*\[tag2\]\(.*\) E: third string/);
+      /D \[.*\] simple string\nI \[.*\] second string\nE \[.*\] third string/);
 
      // set to log messages with level >= info.
     Logging.clearLogs();
@@ -54,7 +54,7 @@ describe("logger from core environment", () => {
     log2.info('second string');
     log2.error('third string');
     expect(Logging.getLogs().join('\n')).toMatch(
-      /\*\[tag2\]\(.*\) I: second string\n\*\[tag2\]\(.*\) E: third string/);
+      /I \[.*\] second string\nE \[.*\] third string/);
 
     // restore back to default.
     Logging.setBufferedLogFilter(['*:E']);
@@ -63,6 +63,6 @@ describe("logger from core environment", () => {
   it('format message like printf', () => {
     log1.error('%1 pinged %2 with id=%3', ['Bob', 'Alice', '123456']);
     expect(Logging.getLogs().join('\n')).toMatch(
-      /\*\[tag1\]\(.*\) E: Bob pinged Alice with id=123456/);
+      /E \[.*\] Bob pinged Alice with id=123456/);
   });
 });

--- a/src/logging/logging.ts
+++ b/src/logging/logging.ts
@@ -66,7 +66,6 @@ module Logging {
   }
 
   export function formatMessage(l:Message) : string {
-    // return '[' + dateToString_(l.timestamp) + '] ' + l.level + ': ' + l.message;
     return l.level + ' [' + dateToString_(l.timestamp) + '] ' + l.message;
   }
 

--- a/src/logging/logging.ts
+++ b/src/logging/logging.ts
@@ -1,3 +1,6 @@
+/// <reference path='../freedom/typings/freedom.d.ts' />
+/// <reference path='../freedom/typings/console.d.ts' />
+
 module Logging {
 
   // The data structure for a logged message.
@@ -11,9 +14,11 @@ module Logging {
   // Besides output to console, log can also be buffered for later retrieval
   // through "getLogs". This is the maximum number of buffered log before it is
   // trimmed. Assuming average log length is 80, the whole buffer size is about
-  // 80k. That should be easy to send through email, not much memory usage, and 
+  // 80k. That should be easy to send through email, not much memory usage, and
   // still enough to capture most issues.
   var MAX_BUFFERED_LOG = 1000;
+
+  var consoleLogger :freedom_Console.Console = freedom['core.console']();
 
   var logBuffer: Message[] = [];
 
@@ -59,19 +64,20 @@ module Logging {
     }
     return formatted_msg;
   }
+
   export function formatMessage(l:Message) : string {
-    return '*[' + l.tag + ']'  + '(' +
-      dateToString_(l.timestamp) + ') ' + l.level + ': ' + l.message;
+    // return '[' + dateToString_(l.timestamp) + '] ' + l.level + ': ' + l.message;
+    return l.level + ' [' + dateToString_(l.timestamp) + '] ' + l.message;
   }
 
   export function makeMessage(level:string, tag:string, msg:string, args?:any[]) : Message {
-    return { timestamp: new Date(),
-        level: level,
-        tag: tag,
-        message: formatStringMessageWithArgs_(msg, args)
-      };
+    return {
+      timestamp: new Date(),
+      level: level,
+      tag: tag,
+      message: formatStringMessageWithArgs_(msg, args)
+    };
   }
-
 
   function checkFilter_(level:string, tag:string, filter:{[s: string]: string;})
       : boolean {
@@ -87,11 +93,11 @@ module Logging {
 
     if (checkFilter_(level, tag, consoleFilter)) {
       if(level === 'D' || level === 'I') {
-        console.log(formatMessage(Message));
+        consoleLogger.log(tag, formatMessage(Message));
       } else if(level === 'W') {
-        console.warn(formatMessage(Message));
+        consoleLogger.warn(tag, formatMessage(Message));
       } else {
-        console.error(formatMessage(Message));
+        consoleLogger.error(tag, formatMessage(Message));
       }
     }
 

--- a/src/logging/mocks.js
+++ b/src/logging/mocks.js
@@ -1,0 +1,6 @@
+// Create a mock instance of Freedom.
+// We do this in a non-TypeScript file because the ambient module declaration
+// prevents us creating any variable called freedom in TypeScript-land.
+var freedom = {};
+freedom['core.console'] = jasmine.createSpy().and.returnValue(
+    jasmine.createSpyObj('core.console', ['log', 'error']));

--- a/src/samples/simple-freedom-chat/freedom-module.json
+++ b/src/samples/simple-freedom-chat/freedom-module.json
@@ -12,6 +12,7 @@
   },
   "permissions": [
     "core.rtcdatachannel",
-    "core.rtcpeerconnection"
+    "core.rtcpeerconnection",
+    "core.console"
   ]
 }

--- a/src/samples/simple-freedom-chat/freedom-module.json
+++ b/src/samples/simple-freedom-chat/freedom-module.json
@@ -11,8 +11,8 @@
     ]
   },
   "permissions": [
+    "core.console",
     "core.rtcdatachannel",
-    "core.rtcpeerconnection",
-    "core.console"
+    "core.rtcpeerconnection"
   ]
 }

--- a/src/samples/simple-freedom-chat/main.html
+++ b/src/samples/simple-freedom-chat/main.html
@@ -1,7 +1,6 @@
 <html>
 <head>
   <title>PeerConnection chat client</title>
-  <script src='lib/logging/logging.js'></script>
   <script src='lib/freedom/freedom.js'></script>
 </head>
 

--- a/src/samples/simple-freedom-chat/main.ts
+++ b/src/samples/simple-freedom-chat/main.ts
@@ -1,8 +1,5 @@
 /// <reference path='messages.d.ts' />
-/// <reference path='../../logging/logging.d.ts' />
 /// <reference path="../../freedom/typings/freedom.d.ts" />
-
-var log :Logging.Log = new Logging.Log('main');
 
 var sendButtonA = document.getElementById("sendButtonA");
 var sendButtonB = document.getElementById("sendButtonB");
@@ -17,13 +14,11 @@ freedom('freedom-module.json', { 'debug': 'log' }).then(function(interface:any) 
   var chat :any = interface();
 
   chat.on('ready', function() {
-    log.info('peer connection established!');
     sendAreaA.disabled = false;
     sendAreaB.disabled = false;
   });
 
   chat.on('error', function() {
-    log.error('something went wrong with the peer connection');
     sendAreaA.disabled = true;
     sendAreaB.disabled = true;
   });
@@ -42,5 +37,5 @@ freedom('freedom-module.json', { 'debug': 'log' }).then(function(interface:any) 
   chat.on('receiveA', receive.bind(null, receiveAreaA));
   chat.on('receiveB', receive.bind(null, receiveAreaB));
 }, (e:Error) => {
-  log.error('could not load freedom: ' + e.message);
+  console.error('could not load freedom: ' + e.message);
 });


### PR DESCRIPTION
This makes our logging class, `Logging.Log`, output to Freedom's `core.console` rather than directly to the browser's `console`.

The advantage of this is that `core.console` is smart enough to route messages to the terminal on Firefox, if you're using `cfx run`.

This does _not_ implement a Freedom "custom logger" which would serve as a central collection point (and filtering, retrieval, etc. etc.). We should consider that in the future but I don't think there's a compelling reason to do it right now (basically, much of the code in `Logger.Log` would move to a custom logger).

`core.console` does a little formatting of its own so I had to tweak `Logging.Log`'s output a little. It now looks like this in Chrome:

![image](https://cloud.githubusercontent.com/assets/5142116/4903718/c79cc990-6442-11e4-9dc8-4319d4a298db.png)
