### PR TITLE
fixed the Freedom interface

### DIFF
--- a/src/freedom/typings/freedom.d.ts
+++ b/src/freedom/typings/freedom.d.ts
@@ -96,9 +96,11 @@ declare module freedom {
   }
 }  // declare module freedom
 
-interface Freedom {
+// The |then| continuation is defined on the global core freedom
+// environment where it is the freedom on/emit interface to the root module.
+interface Freedom extends Thenable<OnAndEmit<any,any>> {
   // Represents the call to freedom().
-  (manifestPath?:string, options?:any): any;
+  (manifestPath?:string, options?:any): void;
 
   // We use this specification so that you can reference any value in freedom by
   // a array-lookup of it's name. One day we'll have a nicer way to do this.


### PR DESCRIPTION
Makes it a thenable so that we can always use `new freedom(...)` even when we want to refer to the Thenable continuation that freedom resulting object gives.  

Note: this is intended to be combined with: uProxy/uproxy#660 ; so it does not break https://github.com/uProxy/uproxy/blob/freedom_0.6/src/chrome/app/scripts/plumbing.ts#L111

Tested: 
1. grunt test
2. sym-linked into node modules of uProxy/uproxy#660 grunt test, and loaded the app/extension of uproxy and looked at console for errors. 

Note: it will still need a package version bump for npm publishing. 

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/95)

<!-- Reviewable:end -->
