### PR TITLE
dramatically reduce compilation startup time

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "17.0.1",
+  "version": "17.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"

--- a/tools/common-grunt-rules.js
+++ b/tools/common-grunt-rules.js
@@ -8,8 +8,8 @@ var exports;
         return {
             src: [
                 'build/' + name + '/**/*.ts',
-                '!**/*.spec.ts',
-                '!**/*.d.ts',
+                '!build/' + name + '/**/*.spec.ts',
+                '!build/' + name + '/**/*.d.ts',
             ],
             options: {
                 sourceRoot: 'build/',

--- a/tools/common-grunt-rules.js
+++ b/tools/common-grunt-rules.js
@@ -54,7 +54,7 @@ var exports;
             cwd: 'build/',
             src: [
                 name + '/**',
-                '!**/*.spec.*'
+                '!' + name + '/**/*.spec.*',
             ],
             dest: 'dist/',
             onlyIf: 'modified'

--- a/tools/common-grunt-rules.ts
+++ b/tools/common-grunt-rules.ts
@@ -8,8 +8,8 @@ module exports {
     return {
       src: [
         'build/' + name + '/**/*.ts',
-        '!**/*.spec.ts',
-        '!**/*.d.ts',
+        '!build/' + name + '/**/*.spec.ts',
+        '!build/' + name + '/**/*.d.ts',
       ],
       options: {
         sourceRoot: 'build/',

--- a/tools/common-grunt-rules.ts
+++ b/tools/common-grunt-rules.ts
@@ -54,7 +54,7 @@ module exports {
       cwd: 'build/',
       src: [
         name + '/**',
-        '!**/*.spec.*'
+        '!' + name + '/**/*.spec.*',
       ],
       dest: 'dist/',
       onlyIf: 'modified',


### PR DESCRIPTION
Limit the exclusion search to the folder containing sources; on my system this reduces recompilation time to just ~1.5s from ~23s for the initial compilation time.

Fixes:
https://github.com/uProxy/uproxy/issues/667

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/99)
<!-- Reviewable:end -->
