### PR TITLE
Edit Jasmine grunt rule to include code coverage.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -86,21 +86,17 @@ module.exports = (grunt) ->
       handler: Rule.jasmineSpec 'handler'
       taskmanager: Rule.jasmineSpec 'taskmanager'
       arraybuffers: Rule.jasmineSpec 'arraybuffers'
-      loggingProvider:
-        src: [
+      loggingProvider: Rule.jasmineSpec('loggingprovider',
+        [
           'build/logging/mocks.js'
           'build/loggingprovider/loggingprovider.js'
-        ]
-        options:
-          specs: 'build/loggingprovider/*.spec.js'
-      logging:
-        src: [
+        ])
+      logging: Rule.jasmineSpec('logging',
+        [
           'build/logging/mocks.js'
           'build/logging/logging.js',
           require.resolve('es6-promise/dist/promise-1.0.0')
-        ]
-        options:
-          specs: 'build/logging/*.spec.js'
+        ])
 
     clean: ['build/', 'dist/', '.tscache/']
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "grunt-contrib-symlink": "~0.3.0",
     "grunt-contrib-uglify": "~0.6.0",
     "grunt-contrib-watch": "~0.6.1",
+    "grunt-template-jasmine-istanbul": "^0.3.0",
     "grunt-ts": "^1.11",
     "typescript": "^1.1.0-1"
   },

--- a/package.json
+++ b/package.json
@@ -16,27 +16,24 @@
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
   ],
-  "dependencies": {
-    "es6-promise": "^1.0.0",
-    "arraybuffer-slice": "~0.1.2",
-    "es5-shim": "^4.0.0"
-  },
   "peerDependencies": {
-    "freedom": "^0.6.11"
+    "freedom": "^0.6.18"
   },
   "devDependencies": {
-    "freedom": "^0.6.4",
-    "grunt": "~0.4.5",
-    "grunt-contrib-jasmine": "~0.7.0",
-    "grunt-contrib-clean": "~0.6.0",
-    "grunt-contrib-coffee": "~0.12.0",
-    "grunt-contrib-copy": "~0.6.0",
-    "grunt-contrib-symlink": "~0.3.0",
-    "grunt-contrib-uglify": "~0.6.0",
-    "grunt-contrib-watch": "~0.6.1",
+    "freedom": "^0.6.18",
+    "es6-promise": "^1.0.0",
+    "arraybuffer-slice": "~0.1.2",
+    "grunt": "^0.4.5",
+    "grunt-contrib-jasmine": "^0.8.2",
+    "grunt-contrib-clean": "^0.6.0",
+    "grunt-contrib-coffee": "^0.12.0",
+    "grunt-contrib-copy": "^0.7.0",
+    "grunt-contrib-symlink": "^0.3.0",
+    "grunt-contrib-uglify": "^0.7.0",
+    "grunt-contrib-watch": "^0.6.1",
     "grunt-template-jasmine-istanbul": "^0.3.0",
-    "grunt-ts": "^1.11",
-    "typescript": "^1.1.0-1"
+    "grunt-ts": "^2.0.1",
+    "typescript": "^1.4.1"
   },
   "scripts": {
     "test": "grunt test",

--- a/src/logging/logging.ts
+++ b/src/logging/logging.ts
@@ -37,7 +37,7 @@ module Logging {
   }
 
   export class Log {
-    private logger :Promise<Freedom.logger>;
+    private logger :Promise<freedom.Logger>;
     constructor(private tag_:string) {
       this.logger = freedom['core']().getLogger(this.tag_);
     }

--- a/src/taskmanager/taskmanager.ts
+++ b/src/taskmanager/taskmanager.ts
@@ -144,5 +144,5 @@ module TaskManager {
 
 // A bit of a hack to allow this file to be compiled normally and still used by
 // commonjs-style require.
-var exports = (exports || {});
+var exports :any = (exports || {});
 exports.Manager = TaskManager.Manager;

--- a/tools/common-grunt-rules.js
+++ b/tools/common-grunt-rules.js
@@ -9,7 +9,7 @@ var exports;
             src: [
                 'build/' + name + '/**/*.ts',
                 '!build/' + name + '/**/*.spec.ts',
-                '!build/' + name + '/**/*.d.ts',
+                '!build/' + name + '/**/*.d.ts'
             ],
             options: {
                 sourceRoot: 'build/',
@@ -23,6 +23,7 @@ var exports;
         };
     }
     exports.typescriptSrc = typescriptSrc;
+
     // Compiles a module's tests and declarations, in order to
     // help test that declarations match their implementation.
     // The files must already be available under build/.
@@ -30,7 +31,7 @@ var exports;
         return {
             src: [
                 'build/' + name + '/**/*.spec.ts',
-                'build/' + name + '/**/*.d.ts',
+                'build/' + name + '/**/*.d.ts'
             ],
             options: {
                 sourceRoot: 'build/',
@@ -44,6 +45,7 @@ var exports;
         };
     }
     exports.typescriptSpecDecl = typescriptSpecDecl;
+
     // Copies a module's directory from build/ to dist/.
     // Test-related files are excluded.
     // CONSIDER: rename to copyModuleToDest so you can understand it when only
@@ -54,13 +56,14 @@ var exports;
             cwd: 'build/',
             src: [
                 name + '/**',
-                '!' + name + '/**/*.spec.*',
+                '!' + name + '/**/*.spec.*'
             ],
             dest: 'dist/',
             onlyIf: 'modified'
         };
     }
     exports.copyModule = copyModule;
+
     // Copies build/* to a sample's directory under dist/.
     // The samples directory itself and TypeScript files are excluded.
     // TODO: copy dist/* instead
@@ -73,7 +76,7 @@ var exports;
                     src: [
                         '**',
                         '!samples/**',
-                        '!**/*.ts',
+                        '!**/*.ts'
                     ],
                     dest: 'dist/' + name + '/lib/',
                     onlyIf: 'modified'
@@ -82,25 +85,46 @@ var exports;
         };
     }
     exports.copySampleFiles = copySampleFiles;
+
     // Function to make jasmine spec assuming expected dir layout.
-    function jasmineSpec(name) {
+    // If the user chooses not to follow the expected dir layout,
+    // they can pass in source files directly (spec assumption is
+    // fixed, however).
+    // This rule also expects grunt-template-jasmine-istanbul
+    // to be available to calculate code coverage.
+    function jasmineSpec(name, srcFiles) {
         var jasmine_helpers = [
             'node_modules/es6-promise/dist/promise-*.js',
             '!node_modules/es6-promise/dist/promise-*amd.js',
             '!node_modules/es6-promise/dist/promise-*.min.js',
             'node_modules/arraybuffer-slice/index.js'
         ];
-        return {
-            src: jasmine_helpers.concat([
+
+        // If user did not pass in source files, assume the expected
+        // dir layout.
+        if (!srcFiles) {
+            srcFiles = jasmine_helpers.concat([
                 'build/' + name + '/**/*.js',
                 '!build/' + name + '/**/*.spec.js'
-            ]),
+            ]);
+        }
+
+        return {
+            src: srcFiles,
             options: {
                 specs: 'build/' + name + '/**/*.spec.js',
-                outfile: 'build/' + name + '/SpecRunner.html',
-                keepRunner: true
+                template: require('grunt-template-jasmine-istanbul'),
+                templateOptions: {
+                    coverage: 'build/coverage/' + name + '/coverage.json',
+                    report: {
+                        type: 'html',
+                        options: {
+                            dir: 'build/coverage/' + name
+                        }
+                    }
+                }
             }
         };
     }
     exports.jasmineSpec = jasmineSpec;
-})(exports || (exports = {})); // module Rules
+})(exports || (exports = {}));


### PR DESCRIPTION
Edited Rule.jasmineSpec so that it measures code coverage by default using grunt-template-jasmine-istanbul.

The updated rule maintains the same directory layout assumption as before*, but now users can also pass in a list of source files instead if they'd like.

*e.g. the dir layout assumption for Rule.jasmineSpec 'example_module' would be:
- code to be tested is all of build/example_module/\*\*/\*.js, excluding build/example_module/\*\*/\*spec.js
- tests are build/example_module/\*\*/*spec.js
Now the code coverage would be summarized at build/coverage/example_module/index.html
Allowing users to specify source files will let them customize the files needed to run tests, e.g. mocks needed for testing.

ran grunt test

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/110)
<!-- Reviewable:end -->
