### PR TITLE
use short month names in logging output

### DIFF
--- a/src/loggingprovider/loggingprovider.ts
+++ b/src/loggingprovider/loggingprovider.ts
@@ -42,7 +42,7 @@ var MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
 
 // Generates current timestamp in form "M d H:m:s.S"
 function dateToString_(d:Date) : string {
-  return MONTH_NAMES[d.Month()] + ' ' + d.getDate() + ' ' +
+  return MONTH_NAMES[d.getMonth()] + ' ' + d.getDate() + ' ' +
       (d.getHours() < 10 ? '0' : '') + d.getHours() + ':' +
       (d.getMinutes() < 10 ? '0' : '') + d.getMinutes() + ':' +
       (d.getSeconds() < 10 ? '0' : '') + d.getSeconds() + '.' +

--- a/src/loggingprovider/loggingprovider.ts
+++ b/src/loggingprovider/loggingprovider.ts
@@ -37,12 +37,12 @@ var bufferedLogFilter: {[s: string]: string;} = {'*': 'E'};
 // to level number.
 var LEVEL_CHARS = 'DIWE';
 
-var MONTH_NAMES = ['', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+var MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
     'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
 // Generates current timestamp in form "M d H:m:s.S"
 function dateToString_(d:Date) : string {
-  return MONTH_NAMES[d.getMonth()] + ' ' + d.getDate() + ' ' +
+  return MONTH_NAMES[d.Month()] + ' ' + d.getDate() + ' ' +
       (d.getHours() < 10 ? '0' : '') + d.getHours() + ':' +
       (d.getMinutes() < 10 ? '0' : '') + d.getMinutes() + ':' +
       (d.getSeconds() < 10 ? '0' : '') + d.getSeconds() + '.' +

--- a/src/loggingprovider/loggingprovider.ts
+++ b/src/loggingprovider/loggingprovider.ts
@@ -37,10 +37,15 @@ var bufferedLogFilter: {[s: string]: string;} = {'*': 'E'};
 // to level number.
 var LEVEL_CHARS = 'DIWE';
 
-// Generates current timestamp in form "m/d H:m:s.S"
+var MONTH_NAMES = ['', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+// Generates current timestamp in form "M d H:m:s.S"
 function dateToString_(d:Date) : string {
-  return d.getMonth() + '/' + d.getDate() + ' ' + d.getHours() +
-      ':' + d.getMinutes() + ':' + d.getSeconds() + '.' +
+  return MONTH_NAMES[d.getMonth()] + ' ' + d.getDate() + ' ' +
+      (d.getHours() < 10 ? '0' : '') + d.getHours() + ':' +
+      (d.getMinutes() < 10 ? '0' : '') + d.getMinutes() + ':' +
+      (d.getSeconds() < 10 ? '0' : '') + d.getSeconds() + '.' +
       d.getMilliseconds();
 }
 


### PR DESCRIPTION
Also, pad minutes, seconds, and hours < 10 with a zero.

Not sure we shouldn't just be outputting ISO 8601 via `Date.toISOString`...but that really doesn't look very pretty.

Output from simple-freedom-chat:

```
PeerConnection D [Feb 17 16:10:46.532] negotiateConnection()
PeerConnection D [Feb 17 16:10:46.532] A: openDataChannel: ; options=undefined
PeerConnection D [Feb 17 16:10:46.535] A: negotiateConnection_
freedomchat I [Feb 17 16:10:46.535] A: connecting...
freedomchat I [Feb 17 16:10:46.539] a: sending signal to b.
PeerConnection D [Feb 17 16:10:46.540] B: handleSignalMessage: 
{"type":0,"description":{"type":"offer","sdp":"v=0\r\no=- 5418801470059999352 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\na=msid-semantic: WMS\r\nm=application 9 DTLS/SCTP 5000\r\nc=IN IP4 0.0.0.0\r\na=ice-ufrag:NvCr/p759b+2UmGf\r\na=ice-pwd:DKtsCzosrACd6wWD+lB5NYoP\r\na=ice-options:google-ice\r\na=fingerprint:sha-256 83:E8:BC:B9:5B:FD:59:B7:F6:A1:B6:97:92:BD:13:AC:9D:E2:34:99:CD:4F:A4:84:6F:10:E2:AC:9A:32:72:54\r\na=setup:actpass\r\na=mid:data\r\na=sctpmap:5000 webrtc-datachannel 1024\r\n"}}
freedomchat I [Feb 17 16:10:46.542] a: sending signal to b.
PeerConnection D [Feb 17 16:10:46.542] B: handleSignalMessage: 
{"type":2,"candidate":{"candidate":"candidate:801158205 1 udp 2122194687 172.26.82.43 35685 typ host generation 0","sdpMid":"data","sdpMLineIndex":0}}
freedomchat I [Feb 17 16:10:46.544] B: connecting...
freedomchat I [Feb 17 16:10:46.547] b: sending signal to a.
PeerConnection D [Feb 17 16:10:46.547] A: handleSignalMessage: 
{"type":1,"description":{"type":"answer","sdp":"v=0\r\no=- 2793905197747986411 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\na=msid-semantic: WMS\r\nm=application 9 DTLS/SCTP 5000\r\nc=IN IP4 0.0.0.0\r\nb=AS:30\r\na=ice-ufrag:dd8LiHah0HPyr/pP\r\na=ice-pwd:pnGkTetaUGbZNaGOVqhc4I+b\r\na=fingerprint:sha-256 83:E8:BC:B9:5B:FD:59:B7:F6:A1:B6:97:92:BD:13:AC:9D:E2:34:99:CD:4F:A4:84:6F:10:E2:AC:9A:32:72:54\r\na=setup:active\r\na=mid:data\r\na=sctpmap:5000 webrtc-datachannel 1024\r\n"}}
freedomchat I [Feb 17 16:10:46.551] b: sending signal to a.
PeerConnection D [Feb 17 16:10:46.551] A: handleSignalMessage: 
{"type":2,"candidate":{"candidate":"candidate:801158205 1 udp 2122194687 172.26.82.43 37690 typ host generation 0","sdpMid":"data","sdpMLineIndex":0}}
freedomchat I [Feb 17 16:10:46.604] a: sending signal to b.
PeerConnection D [Feb 17 16:10:46.604] B: handleSignalMessage: 
{"type":3}
PeerConnection D [Feb 17 16:10:46.605] B: handleSignalMessage: noMoreCandidates
freedomchat I [Feb 17 16:10:46.606] b: sending signal to a.
PeerConnection D [Feb 17 16:10:46.608] A: handleSignalMessage: 
{"type":3}
PeerConnection D [Feb 17 16:10:46.608] A: handleSignalMessage: noMoreCandidates
PeerConnection D [Feb 17 16:10:46.611] completeConnection_, calling fulfillConnected_
freedomchat I [Feb 17 16:10:46.611] A connected
PeerConnection D [Feb 17 16:10:46.613] B: onPeerStartedDataChannel
freedomchat I [Feb 17 16:10:46.613] a: negotiated connection
PeerConnection D [Feb 17 16:10:46.614] A: openDataChannel: text; options=undefined
PeerConnection D [Feb 17 16:10:46.617] B: onPeerStartedDataChannel
freedomchat I [Feb 17 16:10:46.620] B: peerOpenedChannelQueue: text: opennedSuccessfully_=undefined
PeerConnection D [Feb 17 16:10:46.623] completeConnection_, calling fulfillConnected_
freedomchat I [Feb 17 16:10:46.623] B connected
freedomchat I [Feb 17 16:10:46.624] B: onceOpened: text: opennedSuccessfully_=true
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/121)

<!-- Reviewable:end -->
