### PR TITLE
* log level should not override individual tag level

### DIFF
--- a/src/loggingprovider/loggingprovider.spec.ts
+++ b/src/loggingprovider/loggingprovider.spec.ts
@@ -40,6 +40,7 @@ describe("Logging Provider", () => {
   beforeEach(() => {
     logger = new LoggingProvider.Log();
     loggingControl = new LoggingProvider.LoggingController();
+    loggingControl.setBufferedLogFilter(['*:E']);
     loggingControl.clearLogs();
   });
 
@@ -79,9 +80,6 @@ describe("Logging Provider", () => {
     logger.error('tag3', 'third string');
     expect(loggingControl.getLogs().join('\n')).toMatch(
       /I \[.*\] second string\nE \[.*\] third string/);
-
-    // restore back to default.
-    loggingControl.setBufferedLogFilter(['*:E']);
   });
 
   it('Specific filtering level for tag overrides *', () => {
@@ -97,7 +95,5 @@ describe("Logging Provider", () => {
     expect(logs).not.toMatch(/second string/);
     expect(logs).toMatch(/first string/);
     expect(logs).toMatch(/third string/);
-
-    loggingControl.setBufferedLogFilter(['*:E']);
   });
 });

--- a/src/loggingprovider/loggingprovider.spec.ts
+++ b/src/loggingprovider/loggingprovider.spec.ts
@@ -83,4 +83,21 @@ describe("Logging Provider", () => {
     // restore back to default.
     loggingControl.setBufferedLogFilter(['*:E']);
   });
+
+  it('Specific filtering level for tag overrides *', () => {
+    var logs :string;
+    loggingControl.clearLogs();
+    loggingControl.setBufferedLogFilter(['*:D', 'tag2:I']);
+    logger.debug('tag1', 'first string');
+    logger.debug('tag2', 'second string');
+    logger.info('tag3', 'third string');
+
+    logs = loggingControl.getLogs().join('\n');
+
+    expect(logs).not.toMatch(/second string/);
+    expect(logs).toMatch(/first string/);
+    expect(logs).toMatch(/third string/);
+
+    loggingControl.setBufferedLogFilter(['*:E']);
+  });
 });

--- a/src/loggingprovider/loggingprovider.ts
+++ b/src/loggingprovider/loggingprovider.ts
@@ -64,8 +64,13 @@ export function makeMessage(level:string, tag:string, msg:string)
 
 function checkFilter_(level:string, tag:string, filter:{[s: string]: string;})
     : boolean {
-  return '*' in filter && isLevelAllowed_(level, filter['*']) ||
-         tag in filter && isLevelAllowed_(level, filter[tag]);
+  // if we explicitly specify a logging level for the tag, use that
+  if (tag in filter) {
+    return isLevelAllowed_(level, filter[tag]);
+  }
+
+  // if the logging level was not explicitly specified, use * if present
+  return '*' in filter && isLevelAllowed_(level, filter['*']);
 }
 
 // Function that actally adds things to the log and does the console output.


### PR DESCRIPTION
This updates the behaviour of specifying a log level so that, if the
level is specified for a specific module, that will override the level
specified for *.

Closes uproxy/uproxy#906

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/122)

<!-- Reviewable:end -->
