### PR TITLE
Check the buffered amount before sending each queued block.

### DIFF
--- a/src/webrtc/datachannel.ts
+++ b/src/webrtc/datachannel.ts
@@ -127,7 +127,7 @@ export class DataChannelClass implements DataChannel {
     });
     this.onceOpened.then(() => {
       this.opennedSuccessfully_ = true;
-      this.toPeerDataQueue_.setHandler(this.handleSendDataToPeer_);
+      this.toPeerDataQueue_.setNextHandler(this.handleSendDataToPeer_);
     });
     this.onceClosed.then(() => {
         if(!this.opennedSuccessfully_) {
@@ -249,7 +249,14 @@ export class DataChannelClass implements DataChannel {
         setTimeout(this.conjestionControlSendHandler, 20);
       } else {
         if(!this.toPeerDataQueue_.isHandling()) {
-          this.toPeerDataQueue_.setHandler(this.handleSendDataToPeer_);
+          // This processes one block from the queue, which (in Chrome) is
+          // expected to be no larger than 4 KB.  We will then go through the
+          // whole loop again, including checking the buffered amount, before
+          // processing the next block.  This is inefficient because it
+          // introduces an extra IPC call per block; a more efficient
+          // implementation would check the available buffered amount, and
+          // then pull that many bytes off of the queue.
+          this.toPeerDataQueue_.setNextHandler(this.handleSendDataToPeer_);
         }
       }
     });

--- a/src/webrtc/datachannel.ts
+++ b/src/webrtc/datachannel.ts
@@ -242,22 +242,22 @@ export class DataChannelClass implements DataChannel {
   // callback for buffering, we don't need to do this anymore.
   private conjestionControlSendHandler = () : void => {
     this.rtcDataChannel_.getBufferedAmount().then((bufferedAmount:number) => {
+      if(this.toPeerDataQueue_.isHandling()) {
+        log.error('Last packet handler should not still be present');
+        this.close();
+      }
+
       if(bufferedAmount + CHUNK_SIZE > PC_QUEUE_LIMIT) {
-        if(this.toPeerDataQueue_.isHandling()) {
-          this.toPeerDataQueue_.stopHandling();
-        }
         setTimeout(this.conjestionControlSendHandler, 20);
       } else {
-        if(!this.toPeerDataQueue_.isHandling()) {
-          // This processes one block from the queue, which (in Chrome) is
-          // expected to be no larger than 4 KB.  We will then go through the
-          // whole loop again, including checking the buffered amount, before
-          // processing the next block.  This is inefficient because it
-          // introduces an extra IPC call per block; a more efficient
-          // implementation would check the available buffered amount, and
-          // then pull that many bytes off of the queue.
-          this.toPeerDataQueue_.setNextHandler(this.handleSendDataToPeer_);
-        }
+        // This processes one block from the queue, which (in Chrome) is
+        // expected to be no larger than 4 KB.  We will then go through the
+        // whole loop again, including checking the buffered amount, before
+        // processing the next block.  This is inefficient because it
+        // introduces an extra IPC call per block; a more efficient
+        // implementation would check the available buffered amount, and
+        // then pull that many bytes off of the queue.
+        this.toPeerDataQueue_.setNextHandler(this.handleSendDataToPeer_);
       }
     });
   }


### PR DESCRIPTION
Tested using (forthcoming) load tests in uproxy-networking.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/126)

<!-- Reviewable:end -->
