### PR TITLE
Make DataChannel.getBufferedAmount() include all pending data.

### DIFF
--- a/src/webrtc/datachannel.ts
+++ b/src/webrtc/datachannel.ts
@@ -59,8 +59,8 @@ export interface DataChannel {
   getBrowserBufferedAmount() : Promise<number>;
 
   // Returns the number of bytes which have been passed to send() but
-  // which have not yet been handed off to usrsctplib.
-  getTotalBufferedAmount() : Promise<number>;
+  // which have not yet been handed off to the browser.
+  getJavascriptBufferedAmount() : number;
 
   // Closes this data channel.
   // A channel cannot be re-opened once this has been called.
@@ -288,11 +288,8 @@ export class DataChannelClass implements DataChannel {
     return this.rtcDataChannel_.getBufferedAmount();
   }
 
-  public getTotalBufferedAmount = () : Promise<number> => {
-    return this.rtcDataChannel_.getBufferedAmount()
-        .then((browserBytes:number) : number => {
-          return browserBytes + this.toPeerDataBytes_;
-        });
+  public getJavascriptBufferedAmount = () : number => {
+    return this.toPeerDataBytes_;
   }
 
   public toString = () : string => {


### PR DESCRIPTION
Not really tested... but at least it builds and the existing tests pass.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/130)

<!-- Reviewable:end -->
