### PR TITLE
Improvements to setup script and browserify options to make debugging easier

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -13,7 +13,7 @@ function runAndAssertCmd ()
     echo
     # We use set -e to make sure this will fail if the command returns an error
     # code.
-    set -e && $1
+    set -e && eval $1
 }
 
 # Just run the command, ignore errors (e.g. cp fails if a file already exists
@@ -22,7 +22,7 @@ function runCmd ()
 {
     echo "Running: $1"
     echo
-    $1
+    eval $1
 }
 
 function buildTools ()

--- a/setup.sh
+++ b/setup.sh
@@ -30,7 +30,7 @@ function buildTools ()
   runCmd "cd $ROOT_DIR"
   runCmd "mkdir -p build/dev/uproxy-lib/build-tools/"
   runCmd "cp $ROOT_DIR/src/build-tools/*.ts build/dev/uproxy-lib/build-tools/"
-  runAndAssertCmd "./node_modules/.bin/tsc --module commonjs ./build/dev/uproxy-lib/build-tools/*.ts"
+  runAndAssertCmd "./node_modules/.bin/tsc --module commonjs --noImplicitAny ./build/dev/uproxy-lib/build-tools/*.ts"
   runCmd "mkdir -p ./build/tools/"
   runCmd "cp ./build/dev/uproxy-lib/build-tools/*.js ./build/tools/"
 }

--- a/src/build-tools/common-grunt-rules.ts
+++ b/src/build-tools/common-grunt-rules.ts
@@ -101,7 +101,7 @@ export class Rule {
       src: [ path.join(this.config.devBuildPath, filepath + '.spec.js') ],
       dest: path.join(this.config.devBuildPath, filepath + '.spec.static.js'),
       options: {
-        debug: true,
+        debug: false,
         transform: [['browserify-istanbul',
                     { ignore: ['**/mocks/**', '**/*.spec.js'] }]]
       }
@@ -136,13 +136,22 @@ export class Rule {
     // The file-set for npm module files (or npm module output) from each of
     // |npmLibNames| to the destination path.
     copyInfo.npmLibNames.map((npmName) => {
+      var npmModuleDirName :string;
+      if (path.dirname(npmName) === '.') {
+        // Note: |path.dirname(npmName)| gives '.' when |npmName| is just the
+        // npm module name.
+        npmModuleDirName = npmName;
+      } else {
+        npmModuleDirName = path.dirname(npmName);
+      }
+
       var absoluteNpmFilePath = require.resolve(npmName);
       allFilesForlibPaths.push({
           expand: false,
           nonull: true,
           src: [absoluteNpmFilePath],
           dest: path.join(destPath,
-                          path.dirname(npmName),
+                          npmModuleDirName,
                           path.basename(absoluteNpmFilePath)),
           onlyIf: 'modified'
         });

--- a/src/build-tools/common-grunt-rules.ts
+++ b/src/build-tools/common-grunt-rules.ts
@@ -45,7 +45,6 @@ export interface CopyRule {
   files :CopyFilesDescription[];
 }
 
-
 export class Rule {
   constructor(public config :RuleConfig) {}
 
@@ -142,7 +141,9 @@ export class Rule {
           expand: false,
           nonull: true,
           src: [absoluteNpmFilePath],
-          dest: path.join(destPath,path.basename(absoluteNpmFilePath)),
+          dest: path.join(destPath,
+                          path.dirname(npmName),
+                          path.basename(absoluteNpmFilePath)),
           onlyIf: 'modified'
         });
     });

--- a/src/build-tools/common-grunt-rules.ts
+++ b/src/build-tools/common-grunt-rules.ts
@@ -3,7 +3,6 @@
 /// <reference path='../../../third_party/typings/node/node.d.ts' />
 
 import path = require('path');
-import fs = require('fs');
 
 export interface RuleConfig {
   // The path where code in this repository should be built in.

--- a/src/build-tools/common-grunt-rules.ts
+++ b/src/build-tools/common-grunt-rules.ts
@@ -86,28 +86,28 @@ export class Rule {
   }
 
   // Grunt browserify target creator
-  public browserify(filepath:string) : BrowserifyRule {
+  public browserify(filepath:string, options = {
+        browserifyOptions: { standalone: 'browserified_exports' }
+      }) : BrowserifyRule {
     var file = path.join(this.config.devBuildPath, filepath + '.js');
     return {
       src: [ file ],
       dest: path.join(this.config.devBuildPath, filepath + '.static.js'),
-      options: {
-        debug: false,
-      }
+      options: options
     };
   }
 
   // Grunt browserify target creator, instrumented for istanbul
-  public browserifySpec(filepath:string) : BrowserifyRule {
+  public browserifySpec(filepath:string, options = {
+        transform: [['browserify-istanbul',
+                    { ignore: ['**/mocks/**', '**/*.spec.js'] }]],
+        browserifyOptions: { standalone: 'browserified_exports' }
+      }) : BrowserifyRule {
     var file = path.join(this.config.devBuildPath, filepath + '.spec.js');
     return {
       src: [ file ],
       dest: path.join(this.config.devBuildPath, filepath + '.spec.static.js'),
-      options: {
-        debug: false,
-        transform: [['browserify-istanbul',
-                    { ignore: ['**/mocks/**', '**/*.spec.js'] }]]
-      }
+      options: options
     };
   }
 

--- a/src/build-tools/common-grunt-rules.ts
+++ b/src/build-tools/common-grunt-rules.ts
@@ -46,14 +46,6 @@ export interface CopyRule {
   files :CopyFilesDescription[];
 }
 
-function assertFileExists(filePath:string, info:string = '') {
-  if (!fs.existsSync(filePath)) throw new Error(info + '\nMissing file: ' + filePath);
-}
-
-function assertFilesExist(filePaths:string[], info?:string) {
-  filePaths.forEach((p) => { assertFileExists(p, info); });
-}
-
 export class Rule {
   constructor(public config :RuleConfig) {}
 
@@ -96,7 +88,6 @@ export class Rule {
   // Grunt browserify target creator
   public browserify(filepath:string) : BrowserifyRule {
     var file = path.join(this.config.devBuildPath, filepath + '.js');
-    assertFileExists(file, 'browserify:' + filepath);
     return {
       src: [ file ],
       dest: path.join(this.config.devBuildPath, filepath + '.static.js'),
@@ -109,7 +100,6 @@ export class Rule {
   // Grunt browserify target creator, instrumented for istanbul
   public browserifySpec(filepath:string) : BrowserifyRule {
     var file = path.join(this.config.devBuildPath, filepath + '.spec.js');
-    assertFileExists(file, 'browserifySpec:' + filepath);
     return {
       src: [ file ],
       dest: path.join(this.config.devBuildPath, filepath + '.spec.static.js'),

--- a/src/build-tools/common-grunt-rules.ts
+++ b/src/build-tools/common-grunt-rules.ts
@@ -3,6 +3,7 @@
 /// <reference path='../../../third_party/typings/node/node.d.ts' />
 
 import path = require('path');
+import fs = require('fs');
 
 export interface RuleConfig {
   // The path where code in this repository should be built in.
@@ -43,6 +44,14 @@ export interface CopyFilesDescription {
 
 export interface CopyRule {
   files :CopyFilesDescription[];
+}
+
+function assertFileExists(filePath:string, info:string = '') {
+  if (!fs.existsSync(filePath)) throw new Error(info + '\nMissing file: ' + filePath);
+}
+
+function assertFilesExist(filePaths:string[], info?:string) {
+  filePaths.forEach((p) => { assertFileExists(p, info); });
 }
 
 export class Rule {
@@ -86,8 +95,10 @@ export class Rule {
 
   // Grunt browserify target creator
   public browserify(filepath:string) : BrowserifyRule {
+    var file = path.join(this.config.devBuildPath, filepath + '.js');
+    assertFileExists(file, 'browserify:' + filepath);
     return {
-      src: [ path.join(this.config.devBuildPath, filepath + '.js')],
+      src: [ file ],
       dest: path.join(this.config.devBuildPath, filepath + '.static.js'),
       options: {
         debug: false,
@@ -97,8 +108,10 @@ export class Rule {
 
   // Grunt browserify target creator, instrumented for istanbul
   public browserifySpec(filepath:string) : BrowserifyRule {
+    var file = path.join(this.config.devBuildPath, filepath + '.spec.js');
+    assertFileExists(file, 'browserifySpec:' + filepath);
     return {
-      src: [ path.join(this.config.devBuildPath, filepath + '.spec.js') ],
+      src: [ file ],
       dest: path.join(this.config.devBuildPath, filepath + '.spec.static.js'),
       options: {
         debug: false,

--- a/src/build-tools/common-grunt-rules.ts
+++ b/src/build-tools/common-grunt-rules.ts
@@ -90,7 +90,7 @@ export class Rule {
         browserifyOptions: { standalone: 'browserified_exports' }
       }) : BrowserifyRule {
     return {
-      src: [ path.join(this.config.devBuildPath, filepath + '.js'); ],
+      src: [ path.join(this.config.devBuildPath, filepath + '.js') ],
       dest: path.join(this.config.devBuildPath, filepath + '.static.js'),
       options: options
     };
@@ -103,7 +103,7 @@ export class Rule {
         browserifyOptions: { standalone: 'browserified_exports' }
       }) : BrowserifyRule {
     return {
-      src: [ path.join(this.config.devBuildPath, filepath + '.spec.js'); ],
+      src: [ path.join(this.config.devBuildPath, filepath + '.spec.js') ],
       dest: path.join(this.config.devBuildPath, filepath + '.spec.static.js'),
       options: options
     };

--- a/src/build-tools/common-grunt-rules.ts
+++ b/src/build-tools/common-grunt-rules.ts
@@ -89,9 +89,8 @@ export class Rule {
   public browserify(filepath:string, options = {
         browserifyOptions: { standalone: 'browserified_exports' }
       }) : BrowserifyRule {
-    var file = path.join(this.config.devBuildPath, filepath + '.js');
     return {
-      src: [ file ],
+      src: [ path.join(this.config.devBuildPath, filepath + '.js'); ],
       dest: path.join(this.config.devBuildPath, filepath + '.static.js'),
       options: options
     };
@@ -103,9 +102,8 @@ export class Rule {
                     { ignore: ['**/mocks/**', '**/*.spec.js'] }]],
         browserifyOptions: { standalone: 'browserified_exports' }
       }) : BrowserifyRule {
-    var file = path.join(this.config.devBuildPath, filepath + '.spec.js');
     return {
-      src: [ file ],
+      src: [ path.join(this.config.devBuildPath, filepath + '.spec.js'); ],
       dest: path.join(this.config.devBuildPath, filepath + '.spec.static.js'),
       options: options
     };

--- a/src/loggingprovider/freedom-module.ts
+++ b/src/loggingprovider/freedom-module.ts
@@ -5,3 +5,5 @@ import logging_provider = require('./loggingprovider');
 
 freedom().provideSynchronous(logging_provider.Log);
 freedom['loggingcontroller']().provideSynchronous(logging_provider.LoggingController);
+
+export = logging_provider;

--- a/src/loggingprovider/loggingprovider.ts
+++ b/src/loggingprovider/loggingprovider.ts
@@ -5,25 +5,25 @@
 import logging = require('loggingprovider.types');
 
 // The freedom console provider.
-var freedomConsole :freedom_Console.Console = freedom['core.console']();
+export var freedomConsole :freedom_Console.Console = freedom['core.console']();
 
 // Besides output to console, log can also be buffered for later retrieval
 // through "getLogs". This is the maximum number of buffered log before it is
 // trimmed. Assuming average log length is 80, the whole buffer size is about
 // 80k. That should be easy to send through email, not much memory usage, and
 // still enough to capture most issues.
-var MAX_BUFFERED_LOG = 1000;
+export var MAX_BUFFERED_LOG = 1000;
 
 // Logs waiting for the logger to exist.
-var logBuffer: logging.Message[] = [];
+export var logBuffer: logging.Message[] = [];
 
 // TODO: we probably will change it to false as default.
-var enabled = true;
+export var enabled = true;
 
 // This represents a possible destination for log messages.  To make use of
 // this, the class should be inherited from and the log_ method reimplemented
 // to record the message in whichever way is best for that transport.
-class AbstractLoggingDestination {
+export class AbstractLoggingDestination {
   // These filters control what is displayed/saved for the different log types.
   // Entries for each type should be of the form:
   //   'tag': LEVEL
@@ -66,7 +66,7 @@ class AbstractLoggingDestination {
 }
 
 // A logging destination for printing the message directly to the console
-class ConsoleLoggingDestination extends AbstractLoggingDestination {
+export class ConsoleLoggingDestination extends AbstractLoggingDestination {
   constructor() {
     super({'*': 'D'});
   }
@@ -84,7 +84,7 @@ class ConsoleLoggingDestination extends AbstractLoggingDestination {
   }
 }
 
-class BufferedLoggingDestination extends AbstractLoggingDestination {
+export class BufferedLoggingDestination extends AbstractLoggingDestination {
   constructor() {
     super({'*': 'E'});
   }
@@ -97,7 +97,7 @@ class BufferedLoggingDestination extends AbstractLoggingDestination {
   }
 }
 
-var loggingDestinations :{[name :string] :AbstractLoggingDestination} = {};
+export var loggingDestinations :{[name :string] :AbstractLoggingDestination} = {};
 var logDestination = {
   CONSOLE: 'console',
   BUFFERED: 'buffered'

--- a/src/samples/copypaste-freedom-chat/main.html
+++ b/src/samples/copypaste-freedom-chat/main.html
@@ -5,7 +5,7 @@
 
     <link rel="stylesheet" href="main.css">
 
-    <script src='freedom.js'></script>
+    <script src='freedom/freedom.js'></script>
   </head>
 
   <body>

--- a/src/samples/simple-freedom-chat/main.html
+++ b/src/samples/simple-freedom-chat/main.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>PeerConnection chat client</title>
-  <script src='freedom.js'></script>
+  <script src='freedom/freedom.js'></script>
 </head>
 
 <body>


### PR DESCRIPTION
* npm dependencies are placed in their own directory (named after the npm module)
* Setup script
  * uses eval which allows && in the command. 
  * uses strict typescript (--noImplicitAllowAny)
* Allows over-riding of browserify options and makes default have an top level argument named `browserify_exports` so that debugging and interaction with top level values in a chrome interactive console is possible. 
* Exports more stuff for the logging provider top level for easier interactive debugging.

TESTED: 
 * grunt test
 * Ran sample apps 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/131)
<!-- Reviewable:end -->
