### PR TITLE
Add pause() and resume() methods to core.tcpsocket typescript API.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
     }
   ],
   "peerDependencies": {
-    "freedom": "^0.6.19"
+    "freedom": "^0.6.21"
   },
   "devDependencies": {
     "arraybuffer-slice": "^0.1.2",
     "browserify-istanbul": "^0.1.3",
     "es6-promise": "^1.0.0",
-    "freedom": "^0.6.19",
+    "freedom": "^0.6.21",
     "grunt": "^0.4.5",
     "grunt-browserify": "^3.0.1",
     "grunt-contrib-clean": "^0.6.0",

--- a/third_party/freedom-typings/tcp-socket.d.ts
+++ b/third_party/freedom-typings/tcp-socket.d.ts
@@ -39,6 +39,8 @@
       connect(hostname:string, port:number) : Promise<void>;
       secure() : Promise<void>;
       write(data:ArrayBuffer) : Promise<WriteInfo>;
+      pause() : Promise<void>;
+      resume() : Promise<void>;
       getInfo() : Promise<SocketInfo>;
       close() : Promise<void>;
       // TcpSockets have 3 types of events:


### PR DESCRIPTION
Freedom 0.6.21 introduces these new methods, which we would now like to try to use.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/134)

<!-- Reviewable:end -->
