### PR TITLE
remove some uncaught promise warnings during peerconnection setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "20.0.0",
+  "version": "20.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "20.0.1",
+  "version": "20.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"

--- a/src/samples/copypaste-freedom-chat/freedom-module.ts
+++ b/src/samples/copypaste-freedom-chat/freedom-module.ts
@@ -39,7 +39,9 @@ function makePeerConnection() : PeerConnection<SignallingMessage> {
   });
 
   pc.onceConnected.then(() => {
-    log.info('connected');
+    log.info(name + ' connected');
+  }, (e:Error) => {
+    log.error('%1 failed to connect: %2', name, e.message);
   });
 
   pc.peerOpenedChannelQueue.setSyncHandler((d:DataChannel) => {

--- a/src/samples/simple-freedom-chat/freedom-module.ts
+++ b/src/samples/simple-freedom-chat/freedom-module.ts
@@ -11,6 +11,8 @@ import Data = peerconnection.Data;
 
 import Message = require('./message.types');
 
+freedom['loggingcontroller']().setConsoleFilter(['*:D']);
+
 var log :Logging.Log = new Logging.Log('freedomchat');
 
 var parentFreedomModule = freedom();
@@ -49,6 +51,8 @@ function makePeerConnection(name:string) {
   pc.onceConnecting.then(() => { log.info(name + ': connecting...'); });
   pc.onceConnected.then(() => {
     log.info(name + ' connected');
+  }, (e:Error) => {
+    log.error('%1 failed to connect: %2', name, e.message);
   });
   pc.onceDisconnected.then(() => {
     log.info(name + ': onceDisconnected');

--- a/src/webrtc/peerconnection.ts
+++ b/src/webrtc/peerconnection.ts
@@ -207,14 +207,15 @@ export class PeerConnectionClass implements PeerConnection<SignallingMessage> {
       });
 
     // Once connected, add to global listing. Helpful for debugging.
+    // Once disconnected, remove from global listing.
     this.onceConnected.then(() => {
       PeerConnectionClass.peerConnections[this.peerName_] = this;
+      this.onceDisconnected.then(() => {
+        delete PeerConnectionClass.peerConnections[this.peerName_];
+      });
     }, (e:Error) => {
-      // No-op: this is just to avoid uncaught promise warnings.
-    });
-    // Once disconnected, remove from global listing.
-    this.onceDisconnected.then(() => {
-      delete PeerConnectionClass.peerConnections[this.peerName_];
+      log.debug('%1: failed to connect, not available for ' +
+          ' debugging in peerConnections', this.peerName_);
     });
 
     // New data channels from the peer.

--- a/src/webrtc/peerconnection.ts
+++ b/src/webrtc/peerconnection.ts
@@ -209,6 +209,8 @@ export class PeerConnectionClass implements PeerConnection<SignallingMessage> {
     // Once connected, add to global listing. Helpful for debugging.
     this.onceConnected.then(() => {
       PeerConnectionClass.peerConnections[this.peerName_] = this;
+    }, (e:Error) => {
+      // No-op: this is just to avoid uncaught promise warnings.
     });
     // Once disconnected, remove from global listing.
     this.onceDisconnected.then(() => {


### PR DESCRIPTION
This should eliminate the annoying warnings we're seeing when peerconnection setup fails in the UI:
https://github.com/uProxy/uproxy/issues/997

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/135)

<!-- Reviewable:end -->
