### PR TITLE
fix to close call of a freedom manager

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -1,7 +1,6 @@
 language: node_js
 build_image: shippable/minv2
 node_js:
- - "0.12"
  - "0.10"
 before_install:
  - npm install -g grunt-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
- - "0.12"
  - "0.10"
 before_install:
  - npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "20.0.4",
+  "version": "20.0.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"

--- a/third_party/freedom-typings/freedom-common.d.ts
+++ b/third_party/freedom-typings/freedom-common.d.ts
@@ -98,8 +98,9 @@ declare module freedom {
     // module.
     (...args:any[]) : T;
     // This is the call to close a particular stub's channel and resources. It
-    // is assumed that the argument is a result of the factory constructor.
-    close : (freedomModuleStubInstance:T) => Promise<void>;
+    // is assumed that the argument is a result of the factory constructor. If
+    // no argument is supplied, all stubs are closed.
+    close : (freedomModuleStubInstance?:T) => Promise<void>;
   }
 
   interface FreedomInCoreEnvOptions {


### PR DESCRIPTION
Small fix for close arguments of a FreedomModuleFactoryManager.

tested: grunt test

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/141)
<!-- Reviewable:end -->
