### PR TITLE
Add function to set minimum logging level to pass messages to freedom

### DIFF
--- a/src/logging/logging.spec.ts
+++ b/src/logging/logging.spec.ts
@@ -9,6 +9,7 @@ describe('Client logging shim using Freedom', () => {
   beforeEach(() => {
     // Reset the mock freedom environment.
     freedom = freedomMocker.makeMockFreedomInModuleEnv();
+    Logging.setLevels({ '*': Logging.LogLevel.debug });
   });
 
   describe('tag tests', () => {
@@ -38,6 +39,7 @@ describe('Client logging shim using Freedom', () => {
 
   describe('Log messages', () => {
     var mockLoggerPromise :Promise<freedomTypes.Logger>;
+    var log :Logging.Log;
 
     beforeEach(() => {
       var mockLogger = jasmine.createSpyObj<freedomTypes.Logger>('tag',
@@ -45,12 +47,12 @@ describe('Client logging shim using Freedom', () => {
       mockLoggerPromise = Promise.resolve(mockLogger);
 
       spyOn(freedom.core(), 'getLogger').and.returnValue(mockLoggerPromise);
+
+      log = new Logging.Log('tag');
     });
 
     it('A new Logging.Log forwards all logging to the named freedom core logger.',
         (done) => {
-      var log = new Logging.Log('tag');
-
       log.error('test-error-string');
       log.debug('test-debug-string');
 
@@ -63,8 +65,6 @@ describe('Client logging shim using Freedom', () => {
     });
 
     it('Collapses array argument into flattened messages', (done) => {
-      var log = new Logging.Log('tag');
-
       log.info('%1 pinged %2 with id=%3', ['Bob', 'Alice', '123456']);
 
       mockLoggerPromise.then((mockLogger :freedomTypes.Logger) => {
@@ -75,8 +75,6 @@ describe('Client logging shim using Freedom', () => {
     });
 
     it('Collpases arguments into flattened messages', (done) => {
-      var log = new Logging.Log('tag');
-
       log.info('%1 pinged %2 with id=%3', 'Bob', 'Alice', '123456');
       mockLoggerPromise.then((mockLogger :freedomTypes.Logger) => {
         expect(mockLogger.info)
@@ -86,8 +84,6 @@ describe('Client logging shim using Freedom', () => {
     });
 
     it('Adds unspecified arguments to the end', (done) => {
-      var log = new Logging.Log('tag');
-
       log.info('%1', 'foo', 'bar');
       mockLoggerPromise.then((mockLogger :freedomTypes.Logger) => {
         expect(mockLogger.info).toHaveBeenCalledWith('foo bar');
@@ -96,7 +92,6 @@ describe('Client logging shim using Freedom', () => {
     });
 
     it('stringify objects', (done) => {
-      var log = new Logging.Log('tag');
       var obj = { foo: 'bar' };
 
       log.info('%1', obj);
@@ -107,6 +102,21 @@ describe('Client logging shim using Freedom', () => {
       });
     });
 
+    it('check log level', (done) => {
+      Logging.setLevels({
+        'tag': Logging.LogLevel.warn,
+        '*': Logging.LogLevel.debug
+      });
+
+      log.info('this is a test');
+      log.warn('this is not a test');
+
+      mockLoggerPromise.then((mockLogger :freedomTypes.Logger) => {
+        expect(mockLogger.info).not.toHaveBeenCalled();
+        expect(mockLogger.warn).toHaveBeenCalled();
+        done();
+      });
+    });
   });
 
 });


### PR DESCRIPTION
One area we are facing a problem with performance-wise is passing
messages to freedom from the logger.  This involves sending the message
both to the core environment and then to the actual logging module.

To remove that overhead for messages we never intend to do anything
with, this commit adds the ability to set logging levels on the logger
to allow messages to be converted to a noop without any freedom
overhead.

Adds a temporary solution for uProxy/uproxy#1005

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/142)

<!-- Reviewable:end -->
