### PR TITLE
browserify for specs without coverage transform

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -46,7 +46,7 @@ taskManager.add 'copypasteFreedomChat', [
 ]
 
 # Create unit test code
-taskManager.add 'browserify_specs', [
+taskManager.add 'browserifySpecs', [
   'base'
   'browserify:arraybuffersSpec'
   'browserify:handlerSpec'
@@ -56,9 +56,20 @@ taskManager.add 'browserify_specs', [
   'browserify:webrtcSpec'
 ]
 
+# Create unit test code
+taskManager.add 'browserifyCovSpecs', [
+  'base'
+  'browserify:arraybuffersCovSpec'
+  'browserify:handlerCovSpec'
+  'browserify:buildToolsTaskmanagerCovSpec'
+  'browserify:loggingCovSpec'
+  'browserify:loggingProviderCovSpec'
+  'browserify:webrtcCovSpec'
+]
+
 # Run unit tests
 taskManager.add 'unit_test', [
-  'browserify_specs',
+  'browserifySpecs',
   'jasmine:arraybuffers'
   'jasmine:handler'
   'jasmine:buildTools'
@@ -70,7 +81,7 @@ taskManager.add 'unit_test', [
 # Run unit tests to produce coverage; these are separate from unit_tests because
 # they make tests hard to debug and fix.
 taskManager.add 'coverage', [
-  'browserify_specs'
+  'browserifyCovSpecs'
   'jasmine:arraybuffersCov'
   'jasmine:handlerCov'
   'jasmine:buildToolsCov'
@@ -206,11 +217,17 @@ module.exports = (grunt) ->
       loggingProvider: Rule.browserify 'loggingprovider/freedom-module'
       # Browserify specs
       arraybuffersSpec: Rule.browserifySpec 'arraybuffers/arraybuffers'
+      arraybuffersCovSpec: Rule.addCoverageToBrowserify(Rule.browserifySpec 'arraybuffers/arraybuffers')
       buildToolsTaskmanagerSpec: Rule.browserifySpec 'build-tools/taskmanager'
+      buildToolsTaskmanagerCovSpec: Rule.addCoverageToBrowserify(Rule.browserifySpec 'build-tools/taskmanager')
       handlerSpec: Rule.browserifySpec 'handler/queue'
+      handlerCovSpec: Rule.addCoverageToBrowserify(Rule.browserifySpec 'handler/queue')
       loggingProviderSpec: Rule.browserifySpec 'loggingprovider/loggingprovider'
+      loggingProviderCovSpec: Rule.addCoverageToBrowserify(Rule.browserifySpec 'loggingprovider/loggingprovider')
       loggingSpec: Rule.browserifySpec 'logging/logging'
+      loggingCovSpec: Rule.addCoverageToBrowserify(Rule.browserifySpec 'logging/logging')
       webrtcSpec: Rule.browserifySpec 'webrtc/peerconnection'
+      webrtcCovSpec: Rule.addCoverageToBrowserify(Rule.browserifySpec 'webrtc/peerconnection')
       # Browserify sample apps main freedom module and core environments
       copypasteFreedomChatFreedomModule: Rule.browserify 'samples/copypaste-freedom-chat/freedom-module'
       copypasteFreedomChatMain: Rule.browserify 'samples/copypaste-freedom-chat/main.core-env'

--- a/src/build-tools/common-grunt-rules.ts
+++ b/src/build-tools/common-grunt-rules.ts
@@ -39,6 +39,7 @@ export interface BrowserifyRule {
   src :string[];
   dest :string;
   options ?:{
+    transform ?:Object[][];
     debug ?:boolean;
   };
 }
@@ -59,6 +60,7 @@ export interface CopyRule {
 export class Rule {
   constructor(public config :RuleConfig) {}
 
+  // Note: argument is modified (and returned for conveniece);
   public addCoverageToSpec(spec:JasmineRule) :JasmineRule {
     var basePath = path.dirname(spec.options.outfile);
 
@@ -96,7 +98,7 @@ export class Rule {
   // Grunt browserify target creator
   public browserify(filepath:string, options = {
         browserifyOptions: { standalone: 'browserified_exports' }
-      }) : BrowserifyRule {
+      }) :BrowserifyRule {
     return {
       src: [ path.join(this.config.devBuildPath, filepath + '.js') ],
       dest: path.join(this.config.devBuildPath, filepath + '.static.js'),
@@ -104,10 +106,18 @@ export class Rule {
     };
   }
 
+  // Note: argument is modified (and returned for conveniece);
+  public addCoverageToBrowserify(rule:BrowserifyRule) :BrowserifyRule {
+    if(!rule.options.transform) {
+      rule.options.transform = [];
+    }
+    rule.options.transform.push(
+      ['browserify-istanbul', { ignore: ['**/mocks/**', '**/*.spec.js'] }]);
+    return rule
+  }
+
   // Grunt browserify target creator, instrumented for istanbul
   public browserifySpec(filepath:string, options = {
-        transform: [['browserify-istanbul',
-                    { ignore: ['**/mocks/**', '**/*.spec.js'] }]],
         browserifyOptions: { standalone: 'browserified_exports' }
       }) : BrowserifyRule {
     return {


### PR DESCRIPTION
While trying to do some debugging in Chrome of the SpecRunner, I noticed all specs had, by default coverage transforms applied which made them really hard to debug. So I separated coverage browserification from normal browserification. 

TESTED: 
* grunt test
* grunt coverage
* grunt dist

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/145)
<!-- Reviewable:end -->
