### PR TITLE
Make PeerConnection.close() return a Promise.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "20.1.1",
+  "version": "21.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"


### PR DESCRIPTION
This is helpful for CHURN in uproxy-networking, to detect when the
browser is likely to have released the local UDP port.

This is a prerequisite for https://github.com/uProxy/uproxy-networking/pull/227

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/150)

<!-- Reviewable:end -->
