### PR TITLE
small style cleanup and adding `api` to freedom module manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "23.0.0",
+  "version": "23.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"

--- a/src/arraybuffers/accumulator.ts
+++ b/src/arraybuffers/accumulator.ts
@@ -1,4 +1,4 @@
-import ArrayBuffers = require('./arraybuffers');
+import arraybuffers = require('./arraybuffers');
 
 // Small internal utility class for accumulating array buffers into a
 // single buffer (until that buffer is big enough).

--- a/src/arraybuffers/accumulator.ts
+++ b/src/arraybuffers/accumulator.ts
@@ -44,7 +44,7 @@ export class Accumulator {
     var accumulatedSize :number = this.currentSize_;
     this.clear();
     this.onBigEnoughBuffer(
-        ArrayBuffers.concat(buffers, accumulatedSize));
+        arraybuffers.concat(buffers, accumulatedSize));
     return accumulatedSize;
   }
 

--- a/src/arraybuffers/arraybuffers.spec.ts
+++ b/src/arraybuffers/arraybuffers.spec.ts
@@ -28,86 +28,86 @@ var emptyHexString = '';
 
 describe('ArrayBuffers <-> Hex Strings', function() {
   it('byteEquality: emptyArray == emptyArray', function() {
-    expect(ArrayBuffers.byteEquality(emptyArray, emptyArray)).toBe(true);
+    expect(arraybuffers.byteEquality(emptyArray, emptyArray)).toBe(true);
   });
   it('byteEquality: array1 == array1', function() {
-    expect(ArrayBuffers.byteEquality(array1, array1)).toBe(true);
+    expect(arraybuffers.byteEquality(array1, array1)).toBe(true);
   });
   it('byteEquality: array1 != emptyArray', function() {
-    expect(ArrayBuffers.byteEquality(array1, emptyArray)).toBe(false);
+    expect(arraybuffers.byteEquality(array1, emptyArray)).toBe(false);
   });
   it('byteEquality: array1 != array2', function() {
-    expect(ArrayBuffers.byteEquality(array1, array2)).toBe(false);
+    expect(arraybuffers.byteEquality(array1, array2)).toBe(false);
   });
 
   it('Empty Buffer -> Empty Hex', function() {
-    expect(ArrayBuffers.arrayBufferToHexString(emptyArray)).toEqual(emptyHexString);
+    expect(arraybuffers.arrayBufferToHexString(emptyArray)).toEqual(emptyHexString);
   });
   it('Empty Hex -> Empty Buffer', function() {
-    expect(ArrayBuffers.byteEquality(ArrayBuffers.hexStringToArrayBuffer(emptyHexString),
+    expect(arraybuffers.byteEquality(arraybuffers.hexStringToArrayBuffer(emptyHexString),
                                      emptyArray)).toBe(true);
   });
 
   it('Buffer -> Hex', function() {
-    expect(ArrayBuffers.arrayBufferToHexString(emptyArray)).toEqual(emptyString);
-    expect(ArrayBuffers.arrayBufferToHexString(array1)).toEqual(hexString1);
-    expect(ArrayBuffers.arrayBufferToHexString(array2)).toEqual(hexString2);
+    expect(arraybuffers.arrayBufferToHexString(emptyArray)).toEqual(emptyString);
+    expect(arraybuffers.arrayBufferToHexString(array1)).toEqual(hexString1);
+    expect(arraybuffers.arrayBufferToHexString(array2)).toEqual(hexString2);
   });
 
   it('Hex -> Buffer -> Hex = identity', function() {
-    expect(ArrayBuffers.arrayBufferToHexString(ArrayBuffers.hexStringToArrayBuffer(emptyString)))
+    expect(arraybuffers.arrayBufferToHexString(arraybuffers.hexStringToArrayBuffer(emptyString)))
         .toEqual(emptyString);
-    expect(ArrayBuffers.arrayBufferToHexString(ArrayBuffers.hexStringToArrayBuffer(emptyString)))
+    expect(arraybuffers.arrayBufferToHexString(arraybuffers.hexStringToArrayBuffer(emptyString)))
         .not.toEqual(hexString1);
-    expect(ArrayBuffers.arrayBufferToHexString(ArrayBuffers.hexStringToArrayBuffer(hexString1)))
+    expect(arraybuffers.arrayBufferToHexString(arraybuffers.hexStringToArrayBuffer(hexString1)))
         .toEqual(hexString1);
-    expect(ArrayBuffers.arrayBufferToHexString(ArrayBuffers.hexStringToArrayBuffer(hexString2)))
+    expect(arraybuffers.arrayBufferToHexString(arraybuffers.hexStringToArrayBuffer(hexString2)))
         .toEqual(hexString2);
-    expect(ArrayBuffers.arrayBufferToHexString(ArrayBuffers.hexStringToArrayBuffer(hexString1)))
+    expect(arraybuffers.arrayBufferToHexString(arraybuffers.hexStringToArrayBuffer(hexString1)))
         .not.toEqual(hexString2);
   });
 });
 
 describe('ArrayBuffers concat & chunk', function() {
   it('chunk(array12, 6).length == 3', function() {
-    expect(ArrayBuffers.chunk(array12,6).length).toBe(3);
+    expect(arraybuffers.chunk(array12,6).length).toBe(3);
   });
   it('chunk(array12, 1).length == 15', function() {
-    expect(ArrayBuffers.chunk(array12,1).length).toBe(15);
+    expect(arraybuffers.chunk(array12,1).length).toBe(15);
   });
   it('concat(array1,array2) == array12', function() {
-    expect(ArrayBuffers.byteEquality(
-        ArrayBuffers.concat([array1, array2]),
+    expect(arraybuffers.byteEquality(
+        arraybuffers.concat([array1, array2]),
         array12))
       .toBe(true);
   });
   it('concat(chunk(array12, 1)) == array12', function() {
-    expect(ArrayBuffers.byteEquality(
-        ArrayBuffers.concat(ArrayBuffers.chunk(array12,1)),
+    expect(arraybuffers.byteEquality(
+        arraybuffers.concat(arraybuffers.chunk(array12,1)),
         array12))
       .toBe(true);
   });
   it('concat(chunk(array12, 4)) == array12', function() {
-    expect(ArrayBuffers.byteEquality(
-        ArrayBuffers.concat(ArrayBuffers.chunk(array12,4)),
+    expect(arraybuffers.byteEquality(
+        arraybuffers.concat(arraybuffers.chunk(array12,4)),
         array12))
       .toBe(true);
   });
   it('concat(chunk(array12, 5)) == array12', function() {
-    expect(ArrayBuffers.byteEquality(
-        ArrayBuffers.concat(ArrayBuffers.chunk(array12,5)),
+    expect(arraybuffers.byteEquality(
+        arraybuffers.concat(arraybuffers.chunk(array12,5)),
         array12))
       .toBe(true);
   });
   it('concat(chunk(array12, array12.byteLength)) == array12', function() {
-    expect(ArrayBuffers.byteEquality(
-        ArrayBuffers.concat(ArrayBuffers.chunk(array12,array12.byteLength)),
+    expect(arraybuffers.byteEquality(
+        arraybuffers.concat(arraybuffers.chunk(array12,array12.byteLength)),
         array12))
       .toBe(true);
   });
   it('concat(chunk(array12, 20)) == array12', function() {
-    expect(ArrayBuffers.byteEquality(
-        ArrayBuffers.concat(ArrayBuffers.chunk(array12,20)),
+    expect(arraybuffers.byteEquality(
+        arraybuffers.concat(arraybuffers.chunk(array12,20)),
         array12))
       .toBe(true);
   });
@@ -115,63 +115,63 @@ describe('ArrayBuffers concat & chunk', function() {
 
 describe('ArrayBuffers <-> strings', function() {
   it('Empty Buffer -> Empty Hex', function() {
-    expect(ArrayBuffers.arrayBufferToHexString(emptyArray)).toEqual(emptyString);
+    expect(arraybuffers.arrayBufferToHexString(emptyArray)).toEqual(emptyString);
   });
   it('Empty Hex -> Empty Buffer', function() {
-    expect(ArrayBuffers.byteEquality(ArrayBuffers.hexStringToArrayBuffer(emptyString),
+    expect(arraybuffers.byteEquality(arraybuffers.hexStringToArrayBuffer(emptyString),
                                      emptyArray)).toBe(true);
   });
 
   it('Buffer -> String', function() {
-    expect(ArrayBuffers.arrayBufferToHexString(emptyArray)).toEqual(emptyString);
-    expect(ArrayBuffers.arrayBufferToHexString(array1)).toEqual(hexString1);
-    expect(ArrayBuffers.arrayBufferToHexString(array1)).not.toEqual(hexString2);
-    expect(ArrayBuffers.arrayBufferToHexString(array2)).toEqual(hexString2);
+    expect(arraybuffers.arrayBufferToHexString(emptyArray)).toEqual(emptyString);
+    expect(arraybuffers.arrayBufferToHexString(array1)).toEqual(hexString1);
+    expect(arraybuffers.arrayBufferToHexString(array1)).not.toEqual(hexString2);
+    expect(arraybuffers.arrayBufferToHexString(array2)).toEqual(hexString2);
   });
 
   it('String -> Buffer -> String = identity', function() {
-    expect(ArrayBuffers.arrayBufferToString(ArrayBuffers.stringToArrayBuffer(emptyString)))
+    expect(arraybuffers.arrayBufferToString(arraybuffers.stringToArrayBuffer(emptyString)))
         .toEqual(emptyString);
-    expect(ArrayBuffers.arrayBufferToString(ArrayBuffers.stringToArrayBuffer(emptyString)))
+    expect(arraybuffers.arrayBufferToString(arraybuffers.stringToArrayBuffer(emptyString)))
         .not.toEqual(hexString1);
-    expect(ArrayBuffers.arrayBufferToString(ArrayBuffers.stringToArrayBuffer(string1)))
+    expect(arraybuffers.arrayBufferToString(arraybuffers.stringToArrayBuffer(string1)))
         .toEqual(string1);
-    expect(ArrayBuffers.arrayBufferToString(ArrayBuffers.stringToArrayBuffer(string2)))
+    expect(arraybuffers.arrayBufferToString(arraybuffers.stringToArrayBuffer(string2)))
         .toEqual(string2);
-    expect(ArrayBuffers.arrayBufferToString(ArrayBuffers.stringToArrayBuffer(string1)))
+    expect(arraybuffers.arrayBufferToString(arraybuffers.stringToArrayBuffer(string1)))
         .not.toEqual(string2);
   });
 });
 
 describe("ArrayBuffers(UTF8) <-> strings", function() {
   it("Empty Buffer -> Empty String", function() {
-    expect(ArrayBuffers.arrayBufferDecodedAsUtf8String(emptyArray)).toEqual(emptyString);
+    expect(arraybuffers.arrayBufferDecodedAsUtf8String(emptyArray)).toEqual(emptyString);
   });
   it("Empty String -> Empty Buffer", function() {
-    expect(ArrayBuffers.stringToUtf8EncodedArrayBuffer(emptyString).byteLength).toEqual(0);
+    expect(arraybuffers.stringToUtf8EncodedArrayBuffer(emptyString).byteLength).toEqual(0);
   });
 
   it("Buffer(UTF8) -> String", function() {
-    expect(ArrayBuffers.arrayBufferDecodedAsUtf8String(emptyArray)).toEqual(emptyString);
-    expect(ArrayBuffers.arrayBufferDecodedAsUtf8String(array1)).toEqual(string1);
-    expect(ArrayBuffers.arrayBufferDecodedAsUtf8String(array3)).toEqual(string3);
+    expect(arraybuffers.arrayBufferDecodedAsUtf8String(emptyArray)).toEqual(emptyString);
+    expect(arraybuffers.arrayBufferDecodedAsUtf8String(array1)).toEqual(string1);
+    expect(arraybuffers.arrayBufferDecodedAsUtf8String(array3)).toEqual(string3);
   });
 
   it("String -> Buffer(UTF8)", function() {
-    expect(ArrayBuffers.byteEquality(
-        ArrayBuffers.stringToUtf8EncodedArrayBuffer(emptyString), emptyArray)).toBe(true);
-    expect(ArrayBuffers.byteEquality(
-        ArrayBuffers.stringToUtf8EncodedArrayBuffer(string1), array1)).toBe(true);
-    expect(ArrayBuffers.byteEquality(
-        ArrayBuffers.stringToUtf8EncodedArrayBuffer(string3), array3)).toBe(true);
+    expect(arraybuffers.byteEquality(
+        arraybuffers.stringToUtf8EncodedArrayBuffer(emptyString), emptyArray)).toBe(true);
+    expect(arraybuffers.byteEquality(
+        arraybuffers.stringToUtf8EncodedArrayBuffer(string1), array1)).toBe(true);
+    expect(arraybuffers.byteEquality(
+        arraybuffers.stringToUtf8EncodedArrayBuffer(string3), array3)).toBe(true);
   });
 
   it("String -> Buffer(UTF8) -> String = identity", function() {
-    expect(ArrayBuffers.arrayBufferDecodedAsUtf8String(
-        ArrayBuffers.stringToUtf8EncodedArrayBuffer(emptyString))).toEqual(emptyString);
-    expect(ArrayBuffers.arrayBufferDecodedAsUtf8String(
-        ArrayBuffers.stringToUtf8EncodedArrayBuffer(string1))).toEqual(string1);
-    expect(ArrayBuffers.arrayBufferDecodedAsUtf8String(
-        ArrayBuffers.stringToUtf8EncodedArrayBuffer(string3))).toEqual(string3);
+    expect(arraybuffers.arrayBufferDecodedAsUtf8String(
+        arraybuffers.stringToUtf8EncodedArrayBuffer(emptyString))).toEqual(emptyString);
+    expect(arraybuffers.arrayBufferDecodedAsUtf8String(
+        arraybuffers.stringToUtf8EncodedArrayBuffer(string1))).toEqual(string1);
+    expect(arraybuffers.arrayBufferDecodedAsUtf8String(
+        arraybuffers.stringToUtf8EncodedArrayBuffer(string3))).toEqual(string3);
   });
 });

--- a/src/arraybuffers/arraybuffers.spec.ts
+++ b/src/arraybuffers/arraybuffers.spec.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../third_party/typings/jasmine/jasmine.d.ts' />
 
-import ArrayBuffers = require('./arraybuffers');
+import arraybuffers = require('./arraybuffers');
 
 var uint8Array1 = new Uint8Array([12,118,101,114,105,115]);
 var array1 = uint8Array1.buffer;

--- a/third_party/freedom-typings/freedom-common.d.ts
+++ b/third_party/freedom-typings/freedom-common.d.ts
@@ -100,7 +100,8 @@ declare module freedom {
     // This is the call to close a particular stub's channel and resources. It
     // is assumed that the argument is a result of the factory constructor. If
     // no argument is supplied, all stubs are closed.
-    close : (freedomModuleStubInstance?:T) => Promise<void>;
+    close :(freedomModuleStubInstance?:T) => Promise<void>;
+    api   :string;
   }
 
   interface FreedomInCoreEnvOptions {


### PR DESCRIPTION
Summary:
 * Standardize lower-case arraybuffers in specs & accumulator code. 
 * Add `api` field to the freedom module manager interface.

TESTED: 
 * grunt dist

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/156)
<!-- Reviewable:end -->
