### PR TITLE
terminate peerconnection when we believe it has reached an unusable state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "24.1.0",
+  "version": "24.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"

--- a/src/webrtc/datachannel.ts
+++ b/src/webrtc/datachannel.ts
@@ -160,6 +160,8 @@ export class DataChannelClass implements DataChannel {
     this.onceOpened.then(() => {
       this.isOpen_ = true;
       this.conjestionControlSendHandler();
+    }, (e:Error) => {
+      log.error('failed to open: ', e.toString);
     });
     this.onceClosed.then(() => {
         if(!this.isOpen_) {


### PR DESCRIPTION
If we think the peerconnection has become unuseable, we should just pro-actively terminate it. This should give a better user experience when users run into the out-of-order close events issue which, sadly, seems quite easy to trigger on medium to high latency connections.

Related to this issue:
https://github.com/uProxy/uproxy/issues/1289

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/157)

<!-- Reviewable:end -->
