### PR TITLE
Use circular-json to serialize objects for the log

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,13 @@
     }
   ],
   "peerDependencies": {
+    "circular-json": "^0.1.6",
     "freedom": "^0.6.21"
   },
   "devDependencies": {
     "arraybuffer-slice": "^0.1.2",
     "browserify-istanbul": "^0.2.0",
+    "circular-json": "^0.1.6",
     "es6-promise": "^2.0.0",
     "freedom": "^0.6.21",
     "grunt": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "25.0.2",
+  "version": "25.0.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"

--- a/src/logging/logging.spec.ts
+++ b/src/logging/logging.spec.ts
@@ -110,6 +110,18 @@ describe('Client logging shim using Freedom', () => {
       });
     });
 
+    it('handles recursive objects', (done) => {
+      var obj :any = { property: 'value' };
+      obj.pts = obj;
+
+      log.info(obj);
+
+      mockLoggerPromise.then((mockLogger :freedomTypes.Logger) => {
+        expect((<jasmine.Spy>mockLogger.info).calls.mostRecent().args[0]).toMatch(/property/);
+        done();
+      });
+    });
+
     it('responds to level changes', (done) => {
       logginglistener.handleEvent('levelchange', loggingProviderTypes.Level.warn);
 

--- a/src/logging/logging.ts
+++ b/src/logging/logging.ts
@@ -1,8 +1,10 @@
 /// <reference path='../../../third_party/typings/es6-promise/es6-promise.d.ts' />
 /// <reference path='../../../third_party/freedom-typings/freedom-module-env.d.ts' />
+/// <reference path='../../../third_party/typings/circular-json/circular-json.d.ts' />
 
 import freedomTypes = require('freedom.types');
 import loggingProviderTypes = require('../loggingprovider/loggingprovider.types');
+import CircularJSON = require('circular-json');
 
 // Perform log message formatting. Formats an array of arguments to a
 // single string.
@@ -15,7 +17,7 @@ function formatStringMessageWithArgs_(args :Object[])
     var arg = args[i];
     if ('string' !== typeof(arg) && !(arg instanceof String)) {
       try {
-        arg = JSON.stringify(arg);
+        arg = CircularJSON.stringify(arg);
       } catch (e) {
         if (arg && typeof(arg.toString) === 'function') {
           arg = arg.toString();

--- a/third_party/tsd.json
+++ b/third_party/tsd.json
@@ -22,6 +22,9 @@
     },
     "request/request.d.ts": {
       "commit": "338059f48e4e32ef11472bd5a54ad91fb67f8c36"
+    },
+    "circular-json/circular-json.d.ts": {
+      "commit": "cb08e83dd87ace1202d1032a8f275b3efacde5c3"
     }
   }
 }


### PR DESCRIPTION
This allows us to not fail when trying to log recursive objects.

Fixes uProxy/uproxy#1181

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/159)

<!-- Reviewable:end -->
