### PR TITLE
Fix handler queue stats.

### DIFF
--- a/src/handler/queue.spec.ts
+++ b/src/handler/queue.spec.ts
@@ -136,6 +136,22 @@ describe('Handler Queue', function() {
           done();
         })
   });
+
+  it('successive setSyncHandler', function(done) {
+    queue.handle('A');
+    queue.setSyncNextHandler((s:string) => {
+      expect(s).toEqual('A');
+      return 0;
+    }).then(() => {
+      queue.setSyncNextHandler((s2:string) => {
+        expect(s2).toEqual('B');
+        expect(queue.getStats().handler_rejections).toEqual(0);
+        done();
+        return 0;
+      });
+      queue.handle('B');
+    });
+  });
 });  // describe('Handler Queue', ... )
 
 describe('Aggregated Handler Queue', function() {


### PR DESCRIPTION
This also includes a change to avoid calling the reject function
of the preceding NextHandler when it has no effect.

Currently all handler queue stats are `NaN` because they are initialized to `undefined`, not `0`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/160)

<!-- Reviewable:end -->
