### PR TITLE
add a heartbeat to peerconnection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "24.1.0",
+  "version": "25.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"

--- a/src/samples/copypaste-freedom-chat/freedom-module.ts
+++ b/src/samples/copypaste-freedom-chat/freedom-module.ts
@@ -11,8 +11,10 @@ import DataChannel = peerconnection.DataChannel;
 import Data = peerconnection.Data;
 
 export var loggingController = freedom['loggingcontroller']();
-loggingController.setDefaultFilter(loggingTypes.Destination.console, loggingTypes.Level.info);
-loggingController.setDefaultFilter(loggingTypes.Destination.buffered, loggingTypes.Level.debug);
+loggingController.setDefaultFilter(loggingTypes.Destination.console,
+    loggingTypes.Level.debug);
+loggingController.setDefaultFilter(loggingTypes.Destination.buffered,
+    loggingTypes.Level.debug);
 
 
 export var moduleName = 'copypaste-socks';

--- a/src/samples/simple-freedom-chat/freedom-module.ts
+++ b/src/samples/simple-freedom-chat/freedom-module.ts
@@ -98,6 +98,10 @@ a.negotiateConnection()
   .then((aTextDataChannel:DataChannel) => {
     connectDataChannel('A', aTextDataChannel);
     parentFreedomModule.emit('ready', {});
+
+    parentFreedomModule.on('stop', () => {
+      a.close();
+    });
   })
   .catch((e:any) => {
     log.error('error while opening datachannel: ' + e.message);

--- a/src/samples/simple-freedom-chat/freedom-module.ts
+++ b/src/samples/simple-freedom-chat/freedom-module.ts
@@ -13,8 +13,10 @@ import Data = peerconnection.Data;
 import Message = require('./message.types');
 
 export var loggingController = freedom['loggingcontroller']();
-loggingController.setDefaultFilter(loggingTypes.Destination.console, loggingTypes.Level.info);
-loggingController.setDefaultFilter(loggingTypes.Destination.buffered, loggingTypes.Level.debug);
+loggingController.setDefaultFilter(loggingTypes.Destination.console,
+    loggingTypes.Level.debug);
+loggingController.setDefaultFilter(loggingTypes.Destination.buffered,
+    loggingTypes.Level.debug);
 
 export var moduleName = 'freedom-chat';
 export var log :logging.Log = new logging.Log(moduleName);
@@ -96,10 +98,6 @@ a.negotiateConnection()
   .then((aTextDataChannel:DataChannel) => {
     connectDataChannel('A', aTextDataChannel);
     parentFreedomModule.emit('ready', {});
-    // Change logging tolerance once connected. This is to demo how to use the
-    // logging controller. TODO: cleanup provider to show that we are supposed
-    // to do that.
-    freedom['loggingcontroller']().setDefaultFilter(loggingTypes.Destination.console, loggingTypes.Level.info);
   })
   .catch((e:any) => {
     log.error('error while opening datachannel: ' + e.message);

--- a/src/samples/simple-freedom-chat/main.core-env.ts
+++ b/src/samples/simple-freedom-chat/main.core-env.ts
@@ -11,6 +11,8 @@ var sendAreaB = <HTMLInputElement>document.getElementById("sendAreaB");
 var receiveAreaA = <HTMLInputElement>document.getElementById("receiveAreaA");
 var receiveAreaB = <HTMLInputElement>document.getElementById("receiveAreaB");
 
+var stopButton = document.getElementById("stopButton");
+
 freedom('freedom-module.json', {
     'logger': 'uproxy-lib/loggingprovider/freedom-module.json',
     'debug': 'debug'
@@ -42,6 +44,10 @@ freedom('freedom-module.json', {
   }
   chat.on('receiveA', receive.bind(null, receiveAreaA));
   chat.on('receiveB', receive.bind(null, receiveAreaB));
+
+  stopButton.onclick = () => {
+    chat.emit('stop');
+  };
 }, (e:Error) => {
   console.error('could not load freedom: ' + e.message);
 });

--- a/src/samples/simple-freedom-chat/main.html
+++ b/src/samples/simple-freedom-chat/main.html
@@ -21,6 +21,12 @@
     <button id="sendButtonB">Send</button>
   </div>
 
+  <hr>
+
+  <div>
+    <button id="stopButton">Stop</button>
+  </div>
+
   <script src='main.core-env.static.js'></script>
 </body>
 </html>

--- a/src/webrtc/peerconnection.ts
+++ b/src/webrtc/peerconnection.ts
@@ -504,10 +504,9 @@ export class PeerConnectionClass implements PeerConnection<signals.Message> {
   // handled.
   private onPeerStartedDataChannel_ =
       (channelInfo:{channel:string}) : void => {
-      log.debug('%1: peer created channel %2',
-          this.peerName_, channelInfo.channel);
       this.addRtcDataChannel_(channelInfo.channel).then((dc:DataChannel) => {
         var label :string = dc.getLabel();
+        log.debug('%1: peer created channel %2', this.peerName_, label);
         if (label === PeerConnectionClass.CONTROL_CHANNEL_LABEL) {
           // If the peer has started the control channel, register it
           // as this user's control channel as well.

--- a/src/webrtc/peerconnection.ts
+++ b/src/webrtc/peerconnection.ts
@@ -106,10 +106,10 @@ export class PeerConnectionClass implements PeerConnection<signals.Message> {
 
   // Interval, in milliseconds, after which the peerconnection will
   // terminate if no heartbeat is received from the peer.
-  private static HEARTBEAT_TIMEOUT_MS_ = 10000;
+  private static HEARTBEAT_TIMEOUT_MS_ = 30000;
 
   // Interval, in milliseconds, at which heartbeats are sent to the peer.
-  private static HEARTBEAT_INTERVAL_MS_ = 2000;
+  private static HEARTBEAT_INTERVAL_MS_ = 5000;
 
   // Message which is sent for heartbeats.
   private static HEARTBEAT_MESSAGE_ = 'heartbeat';


### PR DESCRIPTION
This helps Firefox detect disconnection, addressing this issue:
https://github.com/uProxy/uproxy/issues/1358

Tested with the copypaste chat sample app and Firefox (getter) with Chrome (giver).

Note that this is a _protocol breaking_ change, since old clients do not send the heartbeat.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/161)

<!-- Reviewable:end -->
