### PR TITLE
add module names to LoggingController.getLogs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "25.0.1",
+  "version": "25.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"


### PR DESCRIPTION
When outputting to the console we go via the freedomjs provider, which pretty prints metadata such as the module name; so, when, exporting to strings we should export all the fields.

Tested with Simple SOCKS and uProxy.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/163)

<!-- Reviewable:end -->
