### PR TITLE
Reduce frequency of calls to getBufferedAmount

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "25.0.3",
+  "version": "25.0.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "grunt-template-jasmine-istanbul": "^0.3.0",
     "grunt-ts": "^3.0.0",
     "tsd": "^0.5.7",
-    "typescript": "^1.4.1"
+    "typescript": "=1.4.1"
   },
   "scripts": {
     "test": "grunt dist"


### PR DESCRIPTION
This appears to increase the throughput of proxying by 33 percent when CPU-limited (equivalent to a 25% reduction in CPU intensity).  This is consistent with performance being IPC-dominated, because this change reduces the number of IPC messages per forwarded block from 5 (TCP 'message' event, getBufferedAmount, response, send, response) to 3 (a 40% reduction).

Extrapolating from these numbers, the remaining 3 IPCs account for 50% of CPU time after this change, so max throughput would double if they could be removed.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/165)

<!-- Reviewable:end -->
