### PR TITLE
Add missing copypaste messages to non-English locales.

### DIFF
--- a/src/samples/copypaste-socks-chromeapp/locales/ar/messages.json
+++ b/src/samples/copypaste-socks-chromeapp/locales/ar/messages.json
@@ -1,60 +1,75 @@
 {
-  "intro": {
-    "message": "هذه عينة التطبيق يحدد الجوارب إنشاء الوكلاء بين اثنين من المستخدمين. تبادل الرسائل الأولي يشير يحدث يدويا (على سبيل المثال، عبر البريد الإلكتروني أو الدردشة)، بينما يستخدم إنشاء الوكلاء لاحق متوافق مع WebRTC."
+  "intro" : {
+    "message" : "هذه عينة التطبيق يحدد الجوارب إنشاء الوكلاء بين اثنين من المستخدمين. تبادل الرسائل الأولي يشير يحدث يدويا (على سبيل المثال، عبر البريد الإلكتروني أو الدردشة)، بينما يستخدم إنشاء الوكلاء لاحق متوافق مع WebRTC."
   },
-  "giveAccess": {
-    "message": "منح حق الوصول"
+  "useCrypto" : {
+    "message" : "Use cryptography to sign/encrypt exchange?"
   },
-  "giveDescription": {
-    "message": "السماح لشخص لمشاركة اتصال الانترنت الخاص بك."
+  "userPublicKey" : {
+    "message" : "Your public key is: "
   },
-  "getAccess": {
-    "message": "الوصول"
+  "friendPublicKey" : {
+    "message" : "Your friend's public key is: "
   },
-  "getDescription": {
-    "message": "تجاوز الحجب عن طريق استخدام اتصال الإنترنت لشخص آخر."
+  "signed" : {
+    "message" : "Signaling message has valid signature!"
   },
-  "italian": {
-    "message": "Italiano"
+  "incorrectlySigned" : {
+    "message" : "Signaling message does not have valid signature!"
   },
-  "english": {
-    "message": "English"
+  "giveAccess" : {
+    "message" : "منح حق الوصول"
   },
-  "arabic": {
-    "message": "العربية"
+  "giveDescription" : {
+    "message" : "السماح لشخص لمشاركة اتصال الانترنت الخاص بك."
   },
-  "farsi": {
-    "message": "فارسی"
+  "getAccess" : {
+    "message" : "الوصول"
   },
-  "pasteAndGenerateReply": {
-    "message": "لصق النص الواردة من الطرف الآخر أدناه وانقر على 'إنشاء الرد \"."
+  "getDescription" : {
+    "message" : "تجاوز الحجب عن طريق استخدام اتصال الإنترنت لشخص آخر."
   },
-  "generateReply": {
-    "message": "توليد الرد"
+  "italian" : {
+    "message" : "Italiano"
   },
-  "copyPasteAndSend": {
-    "message": "نسخ / لصق النص الكامل أعلاه وإرساله إلى الطرف الآخر."
+  "english" : {
+    "message" : "English"
   },
-  "warning": {
-    "message": "تحذير: مراقب الذي يرى هذه الرسالة قد تكون قادرة على تحديد ما إذا كنت تستخدم uProxy، حتى إرسالها عبر قناة خاصة تثق به."
+  "arabic" : {
+    "message" : "العربية"
   },
-  "bytesSent": {
-    "message": " وحدات البايت المرسلة إلى الطرف البعيد."
+  "farsi" : {
+    "message" : "فارسی"
   },
-  "bytesReceived": {
-    "message": " بايت الواردة من الطرف البعيد."
+  "pasteAndGenerateReply" : {
+    "message" : "لصق النص الواردة من الطرف الآخر أدناه وانقر على 'إنشاء الرد \"."
   },
-  "generateHandshakeAndSend": {
-    "message": "انقر فوق الزر أدناه لإنشاء رسالة مصافحة لإرسالها إلى الطرف الآخر. هذه الرسالة بإعلام الطرف الآخر كيفية تحديد موقع لك على الشبكة. هذه المعلومات يمكن أن تنتهي بسرعة، لذلك تشرع إلا عند والطرف الآخر على استعداد."
+  "generateReply" : {
+    "message" : "توليد الرد"
   },
-  "generate": {
-    "message": "انتج"
+  "copyPasteAndSend" : {
+    "message" : "نسخ / لصق النص الكامل أعلاه وإرساله إلى الطرف الآخر."
   },
-  "pasteAndStartProxying": {
-    "message": "لصق النص الواردة من الطرف الآخر أدناه وانقر على 'بدء إنشاء الوكلاء \"."
+  "warning" : {
+    "message" : "تحذير: مراقب الذي يرى هذه الرسالة قد تكون قادرة على تحديد ما إذا كنت تستخدم uProxy، حتى إرسالها عبر قناة خاصة تثق به."
   },
-  "startProxying": {
-    "message": "بدء إنشاء الوكلاء"
+  "bytesSent" : {
+    "message" : " وحدات البايت المرسلة إلى الطرف البعيد."
+  },
+  "bytesReceived" : {
+    "message" : " بايت الواردة من الطرف البعيد."
+  },
+  "generateHandshakeAndSend" : {
+    "message" : "انقر فوق الزر أدناه لإنشاء رسالة مصافحة لإرسالها إلى الطرف الآخر. هذه الرسالة بإعلام الطرف الآخر كيفية تحديد موقع لك على الشبكة. هذه المعلومات يمكن أن تنتهي بسرعة، لذلك تشرع إلا عند والطرف الآخر على استعداد."
+  },
+  "generate" : {
+    "message" : "انتج"
+  },
+  "pasteAndStartProxying" : {
+    "message" : "لصق النص الواردة من الطرف الآخر أدناه وانقر على 'بدء إنشاء الوكلاء \"."
+  },
+  "startProxying" : {
+    "message" : "بدء إنشاء الوكلاء"
   },
   "proxyingStateNotYetAttempted" : {
     "message" : "تقاسم الوضع: في انتظار إدخال المستخدم"

--- a/src/samples/copypaste-socks-chromeapp/locales/en/messages.json
+++ b/src/samples/copypaste-socks-chromeapp/locales/en/messages.json
@@ -35,11 +35,11 @@
   "english" : {
     "message" : "English"
   },
-  "arabic": {
-    "message": "العربية"
+  "arabic" : {
+    "message" : "العربية"
   },  
-  "farsi": {
-    "message": "فارسی"
+  "farsi" : {
+    "message" : "فارسی"
   },  
   "pasteAndGenerateReply" : {
     "message" : "Paste the text received from the other party below and click 'Generate reply'."

--- a/src/samples/copypaste-socks-chromeapp/locales/fa/messages.json
+++ b/src/samples/copypaste-socks-chromeapp/locales/fa/messages.json
@@ -1,60 +1,75 @@
 {
-  "intro": {
-    "message": "این برنامه نمونه وکالتی SOCKS بین دو کاربر را برقرار. تبادل پیام های سیگنالینگ اولیه دستی رخ می دهد (به عنوان مثال، از طریق ایمیل و یا چت)، در حالی که پس از آن با استفاده از وکالتی WebRTC فعال میکند."
+  "intro" : {
+    "message" : "این برنامه نمونه وکالتی SOCKS بین دو کاربر را برقرار. تبادل پیام های سیگنالینگ اولیه دستی رخ می دهد (به عنوان مثال، از طریق ایمیل و یا چت)، در حالی که پس از آن با استفاده از وکالتی WebRTC فعال میکند."
   },
-  "giveAccess": {
-    "message": "دسترسی"
+  "useCrypto" : {
+    "message" : "Use cryptography to sign/encrypt exchange?"
   },
-  "giveDescription": {
-    "message": "اجازه کسی برای به اشتراک گذاشتن اتصال اینترنت شما."
+  "userPublicKey" : {
+    "message" : "Your public key is: "
   },
-  "getAccess": {
-    "message": "دسترسی"
+  "friendPublicKey" : {
+    "message" : "Your friend's public key is: "
   },
-  "getDescription": {
-    "message": "مسدود شده عبور با استفاده از اتصال به اینترنت شخص دیگری."
+  "signed" : {
+    "message" : "Signaling message has valid signature!"
   },
-  "italian": {
-    "message": "Italiano"
+  "incorrectlySigned" : {
+    "message" : "Signaling message does not have valid signature!"
   },
-  "english": {
-    "message": "English"
+  "giveAccess" : {
+    "message" : "دسترسی"
   },
-  "arabic": {
-    "message": "العربية"
+  "giveDescription" : {
+    "message" : "اجازه کسی برای به اشتراک گذاشتن اتصال اینترنت شما."
   },
-  "farsi": {
-    "message": "فارسی"
+  "getAccess" : {
+    "message" : "دسترسی"
   },
-  "pasteAndGenerateReply": {
-    "message": "چسباندن متن دریافت شده از طرف دیگر زیر کلیک کنید و 'تولید پاسخ."
+  "getDescription" : {
+    "message" : "مسدود شده عبور با استفاده از اتصال به اینترنت شخص دیگری."
   },
-  "generateReply": {
-    "message": "تولید پاسخ"
+  "italian" : {
+    "message" : "Italiano"
   },
-  "copyPasteAndSend": {
-    "message": "کپی / چسباندن متن کامل بالا و ارسال آن به طرف دیگر."
+  "english" : {
+    "message" : "English"
   },
-  "warning": {
-    "message": "هشدار: ناظر که این پیام را می بیند ممکن است قادر به تعیین که شما با استفاده از یوپراکسی، بنابراین ارسال آن از طریق یک کانال خصوصی به شما اعتماد."
+  "arabic" : {
+    "message" : "العربية"
   },
-  "bytesSent": {
-    "message": " بایت به حزب از راه دور ارسال می شود."
+  "farsi" : {
+    "message" : "فارسی"
   },
-  "bytesReceived": {
-    "message": " بایت از حزب از راه دور دریافت کرد."
+  "pasteAndGenerateReply" : {
+    "message" : "چسباندن متن دریافت شده از طرف دیگر زیر کلیک کنید و 'تولید پاسخ."
   },
-  "generateHandshakeAndSend": {
-    "message": "دکمه زیر را برای تولید یک پیام دادن به ارسال به طرف دیگر کلیک کنید. این پیام می گوید طرف دیگر چگونه به شما کردهاید در شبکه می باشد. این اطلاعات می تواند به سرعت به پایان می رسد، بنابراین ادامه تنها زمانی که شما و طرف دیگر آماده هستند."
+  "generateReply" : {
+    "message" : "تولید پاسخ"
   },
-  "generate": {
-    "message": "تولید"
+  "copyPasteAndSend" : {
+    "message" : "کپی / چسباندن متن کامل بالا و ارسال آن به طرف دیگر."
   },
-  "pasteAndStartProxying": {
-    "message": "چسباندن متن دریافت شده از طرف دیگر زیر و کلیک کنید 'شروع وکالتی."
+  "warning" : {
+    "message" : "هشدار: ناظر که این پیام را می بیند ممکن است قادر به تعیین که شما با استفاده از یوپراکسی، بنابراین ارسال آن از طریق یک کانال خصوصی به شما اعتماد."
   },
-  "startProxying": {
-    "message": "شروع وکالتی"
+  "bytesSent" : {
+    "message" : " بایت به حزب از راه دور ارسال می شود."
+  },
+  "bytesReceived" : {
+    "message" : " بایت از حزب از راه دور دریافت کرد."
+  },
+  "generateHandshakeAndSend" : {
+    "message" : "دکمه زیر را برای تولید یک پیام دادن به ارسال به طرف دیگر کلیک کنید. این پیام می گوید طرف دیگر چگونه به شما کردهاید در شبکه می باشد. این اطلاعات می تواند به سرعت به پایان می رسد، بنابراین ادامه تنها زمانی که شما و طرف دیگر آماده هستند."
+  },
+  "generate" : {
+    "message" : "تولید"
+  },
+  "pasteAndStartProxying" : {
+    "message" : "چسباندن متن دریافت شده از طرف دیگر زیر و کلیک کنید 'شروع وکالتی."
+  },
+  "startProxying" : {
+    "message" : "شروع وکالتی"
   },
   "proxyingStateNotYetAttempted" : {
     "message" : "به اشتراک گذاری وضعیت: در حال انتظار برای ورودی کاربر"

--- a/src/samples/copypaste-socks-chromeapp/locales/it/messages.json
+++ b/src/samples/copypaste-socks-chromeapp/locales/it/messages.json
@@ -2,6 +2,21 @@
   "intro" : {
     "message" : "Questa applicazione di esempio stabilisce SOCKS proxy tra due utenti. Lo scambio intial di messaggi di segnalazione avviene manualmente (ad esempio, via e-mail o la chat), mentre il successivo inoltro utilizza WebRTC."
   },
+  "useCrypto" : {
+    "message" : "Use cryptography to sign/encrypt exchange?"
+  },
+  "userPublicKey" : {
+    "message" : "Your public key is: "
+  },
+  "friendPublicKey" : {
+    "message" : "Your friend's public key is: "
+  },
+  "signed" : {
+    "message" : "Signaling message has valid signature!"
+  },
+  "incorrectlySigned" : {
+    "message" : "Signaling message does not have valid signature!"
+  },
   "giveAccess" : {
     "message" : "Dare accesso"
   },
@@ -20,11 +35,11 @@
   "english" : {
     "message" : "English"
   },
-  "arabic": {
-    "message": "العربية"
+  "arabic" : {
+    "message" : "العربية"
   },  
-  "farsi": {
-    "message": "فارسی"
+  "farsi" : {
+    "message" : "فارسی"
   },  
   "pasteAndGenerateReply" : {
     "message" : "Incollare il testo ricevuto dall'altra parte sottostante e fare clic su 'Generate risposta'."


### PR DESCRIPTION
I don't know Italian, Arabic, or Farsi sadly, so I just copied the English
messages, but I think it's better than blanks. Also did some whitespace
formatting to make it easier to diff and see which messages are missing.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/170)
<!-- Reviewable:end -->
