### PR TITLE
Allow transient ICE disconnection.

### DIFF
--- a/src/churn/churn.ts
+++ b/src/churn/churn.ts
@@ -195,7 +195,7 @@ var log :logging.Log = new logging.Log('churn');
 
     public onceConnecting :Promise<void>;
     public onceConnected :Promise<void>;
-    public onceDisconnected :Promise<void>;
+    public onceClosed :Promise<void>;
 
     // A short-lived connection used to determine network addresses on which
     // we might be able to communicate with the remote host.
@@ -278,8 +278,8 @@ var log :logging.Log = new logging.Log('churn');
       this.onceConnected = this.obfuscatedConnection_.onceConnected.then(() => {
         this.pcState = peerconnection.State.CONNECTED;
       });
-      this.onceDisconnected = this.obfuscatedConnection_.onceDisconnected.then(
-          () => { this.pcState = peerconnection.State.DISCONNECTED; });
+      this.onceClosed = this.obfuscatedConnection_.onceClosed.then(
+          () => { this.pcState = peerconnection.State.CLOSED; });
 
       // Debugging.
       this.onceProbingComplete_.then((endpoint:NatPair) => {

--- a/src/net/tcp.ts
+++ b/src/net/tcp.ts
@@ -278,7 +278,7 @@ export class Connection {
 
   // isClosed() === state_ === Connection.State.CLOSED iff onceClosed
   // has been rejected or fulfilled. We use isClosed to ensure that we only
-  // fulfill/reject the onceDisconnectd once.
+  // fulfill/reject the onceClosed once.
   private state_ :Connection.State;
   // The underlying Freedom TCP socket.
   private connectionSocket_ :freedom_TcpSocket.Socket;

--- a/src/rtc-to-net/rtc-to-net.spec.ts
+++ b/src/rtc-to-net/rtc-to-net.spec.ts
@@ -63,7 +63,7 @@ describe('RtcToNet', function() {
       negotiateConnection: jasmine.createSpy('negotiateConnection'),
       onceConnecting: noopPromise,
       onceConnected: noopPromise,
-      onceDisconnected: noopPromise,
+      onceClosed: noopPromise,
       peerOpenedChannelQueue: new handler.Queue(),
       close: jasmine.createSpy('close')
     };
@@ -86,7 +86,7 @@ describe('RtcToNet', function() {
 
   it('onceStopped fulfills on peerconnection termination', (done) => {
     mockPeerconnection.onceConnected = voidPromise;
-    mockPeerconnection.onceDisconnected = <any>Promise.resolve();
+    mockPeerconnection.onceClosed = <any>Promise.resolve();
 
     server.start(mockProxyConfig, mockPeerconnection)
       .then(() => { return server.onceStopped; })

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -157,7 +157,7 @@ import logging = require('../logging/logging');
       // fulfills first.  https://github.com/uProxy/uproxy/issues/760
       this.onceReady = this.peerConnection_.onceConnected.then(() => {});
       this.onceReady.catch(this.fulfillStopping_);
-      this.peerConnection_.onceDisconnected
+      this.peerConnection_.onceClosed
         .then(() => {
           log.debug('peerconnection terminated');
         }, (e:Error) => {

--- a/src/samples/copypaste-socks-chromeapp/freedom-module.ts
+++ b/src/samples/copypaste-socks-chromeapp/freedom-module.ts
@@ -85,7 +85,7 @@ parentModule.on('start', () => {
   socksRtc.startFromConfig(
       localhostEndpoint,
       pcConfig,
-      false) // obfuscate
+      true) // obfuscate
     .then((endpoint:net.Endpoint) => {
       log.info('socksRtc ready. listening to SOCKS5 on: ' + JSON.stringify(endpoint));
       log.info('` curl -x socks5h://localhost:9999 www.google.com `')
@@ -110,7 +110,7 @@ parentModule.on('handleSignalMessage', (message:signals.Message) => {
       rtcNet.startFromConfig(
           { allowNonUnicast:true },
           pcConfig,
-          false); // obfuscate
+          true); // obfuscate
       log.info('created rtc-to-net');
 
       // Forward signalling channel messages to the UI.

--- a/src/samples/copypaste-socks-chromeapp/freedom-module.ts
+++ b/src/samples/copypaste-socks-chromeapp/freedom-module.ts
@@ -85,7 +85,7 @@ parentModule.on('start', () => {
   socksRtc.startFromConfig(
       localhostEndpoint,
       pcConfig,
-      true) // obfuscate
+      false) // obfuscate
     .then((endpoint:net.Endpoint) => {
       log.info('socksRtc ready. listening to SOCKS5 on: ' + JSON.stringify(endpoint));
       log.info('` curl -x socks5h://localhost:9999 www.google.com `')
@@ -110,7 +110,7 @@ parentModule.on('handleSignalMessage', (message:signals.Message) => {
       rtcNet.startFromConfig(
           { allowNonUnicast:true },
           pcConfig,
-          true); // obfuscate
+          false); // obfuscate
       log.info('created rtc-to-net');
 
       // Forward signalling channel messages to the UI.

--- a/src/samples/simple-churn-chat-chromeapp/freedom-module.ts
+++ b/src/samples/simple-churn-chat-chromeapp/freedom-module.ts
@@ -63,8 +63,8 @@ function makePeerConnection(name:string) {
   }, (e:Error) => {
     log.error('%1 failed to connect: %2', name, e.message);
   });
-  pc.onceDisconnected.then(() => {
-    log.info(name + ': onceDisconnected');
+  pc.onceClosed.then(() => {
+    log.info(name + ': onceClosed');
   });
   pc.peerOpenedChannelQueue.setSyncHandler((d:DataChannel) => {
     log.info(name + ': peerOpenedChannelQueue: ' + d.toString());

--- a/src/samples/simple-freedom-chat/freedom-module.ts
+++ b/src/samples/simple-freedom-chat/freedom-module.ts
@@ -60,8 +60,8 @@ function makePeerConnection(name:string) {
   }, (e:Error) => {
     log.error('%1 failed to connect: %2', name, e.message);
   });
-  pc.onceDisconnected.then(() => {
-    log.info(name + ': onceDisconnected');
+  pc.onceClosed.then(() => {
+    log.info(name + ': onceClosed');
   });
   pc.peerOpenedChannelQueue.setSyncHandler((d:DataChannel) => {
     log.info(name + ': peerOpenedChannelQueue: ' + d.toString());

--- a/src/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/socks-to-rtc/socks-to-rtc.spec.ts
@@ -78,7 +78,7 @@ describe('SOCKS server', function() {
       negotiateConnection: jasmine.createSpy('negotiateConnection'),
       onceConnecting: noopPromise,
       onceConnected: noopPromise,
-      onceDisconnected: noopPromise,
+      onceClosed: noopPromise,
       close: jasmine.createSpy('close')
     };
   });
@@ -109,7 +109,7 @@ describe('SOCKS server', function() {
     (<any>mockTcpServer.onceListening).and.returnValue(Promise.resolve(mockEndpoint));
     (<any>mockTcpServer.onceShutdown).and.returnValue(voidPromise);
     mockPeerConnection.onceConnected = voidPromise;
-    mockPeerConnection.onceDisconnected = voidPromise;
+    mockPeerConnection.onceClosed = voidPromise;
 
     server.start(mockTcpServer, mockPeerConnection).catch(onceServerStopped).then(done);
   });
@@ -123,7 +123,7 @@ describe('SOCKS server', function() {
     (<any>mockTcpServer.onceListening).and.returnValue(Promise.resolve(mockEndpoint));
     (<any>mockTcpServer.onceShutdown).and.returnValue(terminatePromise);
     mockPeerConnection.onceConnected = voidPromise;
-    mockPeerConnection.onceDisconnected = terminatePromise;
+    mockPeerConnection.onceClosed = terminatePromise;
 
     server.start(mockTcpServer, mockPeerConnection).then(onceServerStopped).then(done);
     terminate();

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -154,7 +154,7 @@ module SocksToRtc {
       this.tcpServer_.onceShutdown().then((kind:tcp.SocketCloseKind) => {
         log.info('server socket closed: %1', tcp.SocketCloseKind[kind]);
       }).then(this.fulfillStopping_);
-      this.peerConnection_.onceDisconnected
+      this.peerConnection_.onceClosed
         .then(() => {
           log.info('peerconnection terminated');
         }, (e:Error) => {

--- a/src/webrtc/datachannel.ts
+++ b/src/webrtc/datachannel.ts
@@ -22,12 +22,12 @@ var CHUNK_SIZE = 1024 * 15;
 // The maximum amount of bytes we should allow to get queued up in
 // peerconnection. Any more and we start queueing in JS. There are two reasons
 // to limit this:
-// 0. Data channels are closed by WebRTC when the buffer fills, so we really
+// 1. Data channels are closed by WebRTC when the buffer fills, so we really
 // don't want that to happen accidentally. More info in this thread, which
 // mentions a limit of 16MB for Chrome 37+ and 100 messages for previous versions:
 //   https://code.google.com/p/webrtc/issues/detail?id=2866
 
-// 1. This limit sets the reaction time for backpressure.  Having extremely fast
+// 2. This limit sets the reaction time for backpressure.  Having extremely fast
 // backpressure reaction time is crucial to preventing a huge backlog of TCP
 // data events.  If CHURN is enabled, this backlog also blocks all UDP data
 // transmission, and if the backlog exceeds 5 seconds, it can cause the

--- a/src/webrtc/datachannel.ts
+++ b/src/webrtc/datachannel.ts
@@ -18,14 +18,32 @@ var log :logging.Log = new logging.Log('DataChannel');
 // TODO: test if we can up this to 16k; test the edge-cases!
 // http://tools.ietf.org/html/draft-ietf-rtcweb-data-channel-07#section-6.6
 var CHUNK_SIZE = 1024 * 15;
+
 // The maximum amount of bytes we should allow to get queued up in
-// peerconnection. Any more and we start queueing in JS. Data channels are
-// closed by WebRTC when the buffer fills, so we really don't want that happen
-// accidentally. More info in this thread (note that 250Kb is well below both
-// the 16MB for Chrome 37+ and "100 messages" of previous versions mentioned):
+// peerconnection. Any more and we start queueing in JS. There are two reasons
+// to limit this:
+// 0. Data channels are closed by WebRTC when the buffer fills, so we really
+// don't want that to happen accidentally. More info in this thread, which
+// mentions a limit of 16MB for Chrome 37+ and 100 messages for previous versions:
 //   https://code.google.com/p/webrtc/issues/detail?id=2866
-// CONSIDER: make it 0. There is no size in the spec.
-export var PC_QUEUE_LIMIT = 1024 * 250;
+
+// 1. This limit sets the reaction time for backpressure.  Having extremely fast
+// backpressure reaction time is crucial to preventing a huge backlog of TCP
+// data events.  If CHURN is enabled, this backlog also blocks all UDP data
+// transmission, and if the backlog exceeds 5 seconds, it can cause the
+// PeerConnection to experience ICE disconnection.
+
+// NOTE: Setting this value to zero gives us the fastest possible backpressure
+// reaction time, by pausing the socket after every message, forcing a call to
+// "getBufferedAmount", and only resuming the socket  after the message is
+// actually sent.  This appears to improve our resilience to disconnection when
+// downloading from super-fast servers
+// (https://github.com/uProxy/uproxy/issues/1511).  However, lowering this
+// value to zero also effectively negates the performance benefits from
+// https://github.com/uProxy/uproxy/issues/1474, and even further regresses
+// the CPU intensity.
+export var PC_QUEUE_LIMIT = 0;
+
 // Javascript has trouble representing integers larger than 2^53. So we simply
 // don't support trying to send array's bigger than that.
 var MAX_MESSAGE_SIZE = Math.pow(2, 53);
@@ -297,7 +315,7 @@ export class DataChannelClass implements DataChannel {
   }
 
   private canSendMore_ = () : boolean => {
-    return this.isOpen_ && this.lastBrowserBufferedAmount_ < PC_QUEUE_LIMIT;
+    return this.isOpen_ && this.lastBrowserBufferedAmount_ <= PC_QUEUE_LIMIT;
   }
 
   private sendNext_ = () : void => {


### PR DESCRIPTION
This change also reduces the data channel send buffer to zero.

Fixes https://github.com/uProxy/uproxy/issues/1511: although ICE disconnection events still occur, they are transient, and do not kill the connection.

Note that removing the sensitivity to ICE disconnection is safe in part because we have a heartbeat to detect long-term connection failures.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/174)

<!-- Reviewable:end -->
