### PR TITLE
fix send-on-close test

### DIFF
--- a/src/webrtc/datachannel.ts
+++ b/src/webrtc/datachannel.ts
@@ -17,7 +17,7 @@ var log :logging.Log = new logging.Log('DataChannel');
 // Messages are limited to a 16KB length by SCTP; we use 15k for safety.
 // TODO: test if we can up this to 16k; test the edge-cases!
 // http://tools.ietf.org/html/draft-ietf-rtcweb-data-channel-07#section-6.6
-var CHUNK_SIZE = 1024 * 15;
+export var CHUNK_SIZE = 1024 * 15;
 
 // The maximum amount of bytes we should allow to get queued up in
 // peerconnection. Any more and we start queueing in JS. There are two reasons


### PR DESCRIPTION
This should fix the Shippable tests. I guess this got broken with some of the recent changes to when we check the brower's buffer size; I don't think anything was really broken, just the test.

I can't remember why set the buffered size to half the maximum amount mid-way through the test, can you?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/176)

<!-- Reviewable:end -->
