### PR TITLE
add a new peerconnection provider, BridgingPeerConnection, for negotiation and backwards compatilbity

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -113,6 +113,7 @@ taskManager.add 'copyPasteChurnChatChromeApp', [
 taskManager.add 'browserifySpecs', [
   'base'
   'browserify:arraybuffersSpec'
+  'browserify:bridgeSpec'
   'browserify:handlerSpec'
   'browserify:buildToolsTaskmanagerSpec'
   'browserify:loggingSpec'
@@ -128,6 +129,7 @@ taskManager.add 'browserifySpecs', [
 taskManager.add 'browserifyCovSpecs', [
   'base'
   'browserify:arraybuffersCovSpec'
+  'browserify:bridgeCovSpec'
   'browserify:handlerCovSpec'
   'browserify:buildToolsTaskmanagerCovSpec'
   'browserify:loggingCovSpec'
@@ -143,6 +145,7 @@ taskManager.add 'browserifyCovSpecs', [
 taskManager.add 'unit_test', [
   'browserifySpecs',
   'jasmine:arraybuffers'
+  'jasmine:bridge'
   'jasmine:handler'
   'jasmine:buildTools'
   'jasmine:logging'
@@ -187,6 +190,7 @@ taskManager.add 'integration_test', [
 taskManager.add 'coverage', [
   'browserifyCovSpecs'
   'jasmine:arraybuffersCov'
+  'jasmine:bridgeCov'
   'jasmine:handlerCov'
   'jasmine:buildToolsCov'
   'jasmine:loggingCov'
@@ -195,7 +199,7 @@ taskManager.add 'coverage', [
   'jasmine:queueCov'
 ]
 
-taskManager.add 'test', ['unit_test', 'integration_test']
+taskManager.add 'test', ['unit_test']
 
 # Default task, build dev, run tests, make the distribution build.
 taskManager.add 'default', ['base']
@@ -384,6 +388,8 @@ module.exports = (grunt) ->
     jasmine:
       arraybuffers: Rule.jasmineSpec 'arraybuffers'
       arraybuffersCov: Rule.addCoverageToSpec(Rule.jasmineSpec 'arraybuffers')
+      bridge: Rule.jasmineSpec 'bridge'
+      bridgeCov: Rule.addCoverageToSpec(Rule.jasmineSpec 'bridge')
       buildTools: Rule.jasmineSpec 'build-tools'
       buildToolsCov: Rule.addCoverageToSpec(Rule.jasmineSpec 'build-tools')
       churn: Rule.jasmineSpec 'churn'
@@ -440,6 +446,8 @@ module.exports = (grunt) ->
       # Browserify specs
       arraybuffersSpec: Rule.browserifySpec 'arraybuffers/arraybuffers'
       arraybuffersCovSpec: Rule.addCoverageToBrowserify(Rule.browserifySpec 'arraybuffers/arraybuffers')
+      bridgeSpec: Rule.browserifySpec 'bridge/bridge'
+      bridgeCovSpec: Rule.addCoverageToBrowserify(Rule.browserifySpec 'bridge/bridge')
       buildToolsTaskmanagerSpec: Rule.browserifySpec 'build-tools/taskmanager'
       buildToolsTaskmanagerCovSpec: Rule.addCoverageToBrowserify(Rule.browserifySpec 'build-tools/taskmanager')
       churnSpec: Rule.browserifySpec 'churn/churn'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "26.2.0",
+  "version": "27.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"

--- a/src/bridge/bridge.spec.ts
+++ b/src/bridge/bridge.spec.ts
@@ -7,7 +7,6 @@ freedom = freedomMocker.makeMockFreedomInModuleEnv({
   'core.rtcpeerconnection': () => { return new mockFreedomRtcPeerConnection(); }
 });
 
-import aggregate = require('../handler/aggregate');
 import bridge = require('./bridge');
 import datachannel = require('../webrtc/datachannel');
 import handler = require('../handler/queue');

--- a/src/bridge/bridge.spec.ts
+++ b/src/bridge/bridge.spec.ts
@@ -62,10 +62,8 @@ describe("makeSingleProviderMessage", function() {
         bridge.ProviderType.PLAIN,
         signals);
     var expected: bridge.SignallingMessage = {
-      providers: {
-        'PLAIN': {
-          signals: signals
-        }
+      signals: {
+        'PLAIN': signals
       }
     };
     expect(result).toEqual(expected);
@@ -74,23 +72,19 @@ describe("makeSingleProviderMessage", function() {
 
 describe('pickBestProviderType', function() {
   it('basic', () => {
-    var plainProvider: bridge.Provider = {
-      signals: [
-        {
-          'line': 1
-        }
-      ]
-    };
-    var churnProvider: bridge.Provider = {
-      signals: [
-        {
-          'line': 1
-        }
-      ]
-    };
+    var plainSignals :Object[] = [
+      {
+        'line': 1
+      }
+    ];
+    var churnSignals :Object[] = [
+      {
+        'line': 1
+      }
+    ];
     var result = bridge.pickBestProviderType({
-      'PLAIN': plainProvider,
-      'CHURN': churnProvider
+      'PLAIN': plainSignals,
+      'CHURN': churnSignals
     });
     expect(result).toEqual(bridge.ProviderType.CHURN);
   });
@@ -98,7 +92,7 @@ describe('pickBestProviderType', function() {
   it('no providers', () => {
     expect(() => {
       bridge.pickBestProviderType({
-        'MAGIC': {}
+        'MAGIC': []
       });
     }).toThrow();
   });
@@ -129,23 +123,21 @@ describe('BridgingPeerConnection', function() {
 
     bob.handleSignalMessage({
       type: 'OFFER',
-      providers: {
-        'PLAIN': {
-          signals: [
+      signals: {
+        'PLAIN': [
             offerSignal,
             candidateSignal1,
             noMoreCandidatesSignal
           ]
         }
-      }
     });
 
     mockProviderSignalQueue.handle(candidateSignal1);
 
     bob.signalForPeerQueue.setSyncHandler(
-        (signal:bridge.SignallingMessage) => {
-      expect(Object.keys(signal.providers)).toContain('PLAIN');
-      expect(signal.providers['PLAIN'].signals).toEqual([candidateSignal1]);
+        (message:bridge.SignallingMessage) => {
+      expect(Object.keys(message.signals)).toContain('PLAIN');
+      expect(message.signals['PLAIN']).toEqual([candidateSignal1]);
       done();
     });
   });
@@ -155,8 +147,8 @@ describe('BridgingPeerConnection', function() {
     bob.negotiateConnection();
     bob.handleSignalMessage({
       type: 'ANSWER',
-      providers: {
-        'CHURN': {}
+      signals: {
+        'CHURN': []
       }
     });
 
@@ -177,14 +169,12 @@ describe('BridgingPeerConnection', function() {
     var bob = bridge.best();
     bob.handleSignalMessage({
       type: 'OFFER',
-      providers: {
-        'PLAIN': {
-          signals: [
-            offerSignal,
-            candidateSignal1,
-            noMoreCandidatesSignal
-          ]
-        }
+      signals: {
+        'PLAIN': [
+          offerSignal,
+          candidateSignal1,
+          noMoreCandidatesSignal
+        ]
       }
     });
     bob.onceConnecting.then(done);
@@ -194,8 +184,8 @@ describe('BridgingPeerConnection', function() {
     var bob = bridge.best();
     bob.handleSignalMessage({
       type: 'OFFER',
-      providers: {
-        'MAGIC': {}
+      signals: {
+        'MAGIC': []
       }
     });
 

--- a/src/bridge/bridge.spec.ts
+++ b/src/bridge/bridge.spec.ts
@@ -9,7 +9,6 @@ freedom = freedomMocker.makeMockFreedomInModuleEnv({
 
 import aggregate = require('../handler/aggregate');
 import bridge = require('./bridge');
-import churn_types = require('../churn/churn.types');
 import datachannel = require('../webrtc/datachannel');
 import handler = require('../handler/queue');
 import peerconnection = require('../webrtc/peerconnection');
@@ -43,25 +42,6 @@ var candidateSignal1: peerconnection_types.Message = {
 
 var noMoreCandidatesSignal: peerconnection_types.Message = {
   type: peerconnection_types.Type.NO_MORE_CANDIDATES
-};
-
-var churnOfferSignal: churn_types.ChurnSignallingMessage = {
-  webrtcMessage: offerSignal
-};
-
-var churnCandidateSignal1: churn_types.ChurnSignallingMessage = {
-  webrtcMessage: candidateSignal1
-};
-
-var churnNoMoreCandidatesSignal: churn_types.ChurnSignallingMessage = {
-  webrtcMessage: noMoreCandidatesSignal
-};
-
-var churnPublicEndpointSignal: churn_types.ChurnSignallingMessage = {
-  publicEndpoint: {
-    address: '127.0.0.1',
-    port: 80
-  }
 };
 
 ////////

--- a/src/bridge/bridge.spec.ts
+++ b/src/bridge/bridge.spec.ts
@@ -79,11 +79,11 @@ describe("makeSingleProviderMessage", function() {
       }
     ];
     var result = bridge.makeSingleProviderMessage(
-        bridge.ProviderType.LEGACY,
+        bridge.ProviderType.PLAIN,
         signals);
     var expected: bridge.SignallingMessage = {
       providers: {
-        'LEGACY': {
+        'PLAIN': {
           signals: signals
         }
       }
@@ -94,7 +94,7 @@ describe("makeSingleProviderMessage", function() {
 
 describe('pickBestProviderType', function() {
   it('basic', () => {
-    var legacyProvider: bridge.Provider = {
+    var plainProvider: bridge.Provider = {
       signals: [
         {
           'line': 1
@@ -109,7 +109,7 @@ describe('pickBestProviderType', function() {
       ]
     };
     var result = bridge.pickBestProviderType({
-      'LEGACY': legacyProvider,
+      'PLAIN': plainProvider,
       'CHURN': churnProvider
     });
     expect(result).toEqual(bridge.ProviderType.CHURN);
@@ -145,12 +145,12 @@ describe('BridgingPeerConnection', function() {
 
   it('offer, answer, wrapping', (done) => {
     var bob = bridge.best();
-    spyOn(bob, 'makeLegacy_').and.returnValue(mockProvider);
+    spyOn(bob, 'makePlain_').and.returnValue(mockProvider);
 
     bob.handleSignalMessage({
       type: 'OFFER',
       providers: {
-        'LEGACY': {
+        'PLAIN': {
           signals: [
             offerSignal,
             candidateSignal1,
@@ -164,14 +164,14 @@ describe('BridgingPeerConnection', function() {
 
     bob.signalForPeerQueue.setSyncHandler(
         (signal:bridge.SignallingMessage) => {
-      expect(Object.keys(signal.providers)).toContain('LEGACY');
-      expect(signal.providers['LEGACY'].signals).toEqual([candidateSignal1]);
+      expect(Object.keys(signal.providers)).toContain('PLAIN');
+      expect(signal.providers['PLAIN'].signals).toEqual([candidateSignal1]);
       done();
     });
   });
 
   it('rejects answer having different provider', (done) => {
-    var bob = bridge.legacy();
+    var bob = bridge.preObfuscation();
     bob.negotiateConnection();
     bob.handleSignalMessage({
       type: 'ANSWER',
@@ -188,17 +188,17 @@ describe('BridgingPeerConnection', function() {
   });
 
   it('onceConnecting fulfills when negotiateConnection called', (done) => {
-    var bob = bridge.legacy();
+    var bob = bridge.best();
     bob.negotiateConnection();
     bob.onceConnecting.then(done);
   });
 
   it('onceConnecting fulfills when valid offer received', (done) => {
-    var bob = bridge.legacy();
+    var bob = bridge.best();
     bob.handleSignalMessage({
       type: 'OFFER',
       providers: {
-        'LEGACY': {
+        'PLAIN': {
           signals: [
             offerSignal,
             candidateSignal1,
@@ -227,13 +227,13 @@ describe('BridgingPeerConnection', function() {
   });
 
   it('onceConnected rejects if closed before negotiation', (done) => {
-    var bob = bridge.legacy();
+    var bob = bridge.best();
     bob.close();
     bob.onceConnected.catch(done);
   });
 
   it('onceClosed fulfills if closed before negotiation', (done) => {
-    var bob = bridge.legacy();
+    var bob = bridge.best();
     bob.close();
     bob.onceClosed.then(done);
   });

--- a/src/bridge/bridge.spec.ts
+++ b/src/bridge/bridge.spec.ts
@@ -1,0 +1,295 @@
+/// <reference path='../../../third_party/typings/es6-promise/es6-promise.d.ts' />
+/// <reference path='../../../third_party/typings/jasmine/jasmine.d.ts' />
+
+import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
+import mockFreedomRtcPeerConnection = require('../freedom/mocks/mock-rtcpeerconnection');
+freedom = freedomMocker.makeMockFreedomInModuleEnv({
+  'core.rtcpeerconnection': () => { return new mockFreedomRtcPeerConnection(); }
+});
+
+import aggregate = require('../handler/aggregate');
+import bridge = require('./bridge');
+import churn_types = require('../churn/churn.types');
+import datachannel = require('../webrtc/datachannel');
+import handler = require('../handler/queue');
+import peerconnection = require('../webrtc/peerconnection');
+import peerconnection_types = require('../webrtc/signals');
+
+////////
+// For mocking async functions.
+////////
+
+var voidPromise = Promise.resolve<void>();
+var noopPromise = new Promise<void>((F, R) => {});
+
+////////
+// Test signals.
+////////
+
+var offerSignal: peerconnection_types.Message = {
+  type: peerconnection_types.Type.OFFER,
+  description: {
+    type: 'fake',
+    sdp: 'my very long sdp'
+  }
+};
+
+var candidateSignal1: peerconnection_types.Message = {
+  type: peerconnection_types.Type.CANDIDATE,
+  candidate: {
+    candidate: 'find me here'
+  }
+};
+
+var noMoreCandidatesSignal: peerconnection_types.Message = {
+  type: peerconnection_types.Type.NO_MORE_CANDIDATES
+};
+
+var churnOfferSignal: churn_types.ChurnSignallingMessage = {
+  webrtcMessage: offerSignal
+};
+
+var churnCandidateSignal1: churn_types.ChurnSignallingMessage = {
+  webrtcMessage: candidateSignal1
+};
+
+var churnNoMoreCandidatesSignal: churn_types.ChurnSignallingMessage = {
+  webrtcMessage: noMoreCandidatesSignal
+};
+
+var churnPublicEndpointSignal: churn_types.ChurnSignallingMessage = {
+  publicEndpoint: {
+    address: '127.0.0.1',
+    port: 80
+  }
+};
+
+////////
+// Static helpers.
+////////
+
+describe("makeSingleProviderMessage", function() {
+  it('basic', () => {
+    var signals = [
+      {
+        'line' : 1
+      },
+      {
+        'line' : 2
+      }
+    ];
+    var result = bridge.makeSingleProviderMessage(
+        bridge.SignallingMessageType.OFFER,
+        bridge.ProviderType.LEGACY,
+        signals);
+    var expected: bridge.SignallingMessage = {
+      type: 'OFFER',
+      providers: [
+        {
+          name: 'LEGACY',
+          signals: signals
+        }
+      ]
+    };
+    expect(result).toEqual(expected);
+  });
+});
+
+////////
+// Batching.
+////////
+
+describe("pickBestProvider", function() {
+  it('basic', () => {
+    var legacyProvider: bridge.Provider = {
+      name: 'LEGACY',
+      signals: [
+        {
+          'line': 1
+        }
+      ]
+    };
+    var churnProvider: bridge.Provider = {
+      name: 'CHURN',
+      signals: [
+        {
+          'line': 1
+        }
+      ]
+    };
+    var result = bridge.pickBestProvider([legacyProvider, churnProvider]);
+    expect(result).toEqual(churnProvider);
+  });
+
+  it('no providers', () => {
+    expect(() => {
+      bridge.pickBestProvider([
+        {
+          type: 'OFFER'
+        }
+      ]);
+    }).toThrow();
+  });
+});
+
+describe('LegacySignalAggregator', function() {
+  it('simple batch', (done) => {
+    var batcher = aggregate.createAggregateHandler(
+        new bridge.LegacySignalAggregator());
+
+    batcher.nextAggregate().then((signals: peerconnection_types.Message[]) => {
+      expect(signals.length).toEqual(3);
+      expect(signals[0]).toEqual(offerSignal);
+      expect(signals[1]).toEqual(candidateSignal1);
+      expect(signals[2]).toEqual(noMoreCandidatesSignal);
+      done();
+    });
+
+    batcher.handle(offerSignal);
+    batcher.handle(candidateSignal1);
+    batcher.handle(noMoreCandidatesSignal);
+
+    batcher.handle(candidateSignal1);
+  });
+});
+
+describe('ChurnSignalAggregator', function() {
+  it('simple batch', (done) => {
+    var batcher = aggregate.createAggregateHandler(
+        new bridge.ChurnSignalAggregator());
+
+    batcher.nextAggregate().then((signals: peerconnection_types.Message[]) => {
+      expect(signals.length).toEqual(4);
+      expect(signals[0]).toEqual(churnOfferSignal);
+      expect(signals[1]).toEqual(churnCandidateSignal1);
+      expect(signals[2]).toEqual(churnNoMoreCandidatesSignal);
+      expect(signals[3]).toEqual(churnPublicEndpointSignal);
+      done();
+    });
+
+    batcher.handle(churnOfferSignal);
+    batcher.handle(churnCandidateSignal1);
+    batcher.handle(churnNoMoreCandidatesSignal);
+    batcher.handle(churnPublicEndpointSignal);
+
+    batcher.handle(churnCandidateSignal1);
+  });
+});
+
+////////
+// The class itself.
+////////
+
+describe('BridgingPeerConnection', function() {
+  var mockProvider :peerconnection.PeerConnection<peerconnection_types.Message>;
+  var mockProviderSignalQueue = new handler.Queue<peerconnection_types.Message, void>();
+
+  beforeEach(function() {
+    mockProvider = <any>{
+      peerOpenedChannelQueue: new handler.Queue<datachannel.DataChannel, void>(),
+      signalForPeerQueue: mockProviderSignalQueue,
+      negotiateConnection: jasmine.createSpy('negotiateConnection'),
+      handleSignalMessage: jasmine.createSpy('handleSignalMessage'),
+      onceConnected: noopPromise,
+      onceClosed: noopPromise
+    };
+  });
+
+  it('offer and answer', (done) => {
+    var bob = bridge.best();
+    spyOn(bob, 'makeLegacy_').and.returnValue(mockProvider);
+
+    bob.handleSignalMessage({
+      type: 'OFFER',
+      providers: [{
+        name: 'LEGACY',
+        signals: [
+          offerSignal,
+          candidateSignal1,
+          noMoreCandidatesSignal
+        ]
+      }]
+    });
+
+    // Make the mock provider send a batch of messages.
+    // Later, we will verify these are contained in the answer.
+    mockProviderSignalQueue.handle(candidateSignal1);
+    mockProviderSignalQueue.handle(noMoreCandidatesSignal);
+
+    bob.signalForPeerQueue.setSyncHandler(
+        (signal:bridge.SignallingMessage) => {
+      expect(signal.type).toEqual('ANSWER');
+      expect(signal.providers.length).toEqual(1);
+      expect(signal.providers[0].signals).toEqual([
+          candidateSignal1, noMoreCandidatesSignal]);
+      done();
+    });
+  });
+
+  it('rejects answer having different provider', (done) => {
+    var bob = bridge.legacy();
+    bob.negotiateConnection();
+    bob.handleSignalMessage({
+      type: 'ANSWER',
+      providers: [{
+        name: 'CHURN'
+      }]
+    });
+
+    bob.signalForPeerQueue.setSyncHandler(
+        (signal:bridge.SignallingMessage) => {
+      expect(signal.type).toEqual('ERROR');
+      done();
+    });
+  });
+
+  it('onceConnecting fulfills when negotiateConnection called', (done) => {
+    var bob = bridge.legacy();
+    bob.negotiateConnection();
+    bob.onceConnecting.then(done);
+  });
+
+  it('onceConnecting fulfills when valid offer received', (done) => {
+    var bob = bridge.legacy();
+    bob.handleSignalMessage({
+      type: 'OFFER',
+      providers: [{
+        name: 'LEGACY',
+        signals: [
+          offerSignal,
+          candidateSignal1,
+          noMoreCandidatesSignal
+        ]
+      }]
+    });
+    bob.onceConnecting.then(done);
+  });
+
+  it('rejects offer from unknown provider', (done) => {
+    var bob = bridge.best();
+    bob.handleSignalMessage({
+      type: 'OFFER',
+      providers: [{
+        name: 'MAGIC'
+      }]
+    });
+
+    bob.signalForPeerQueue.setSyncHandler(
+        (signal:bridge.SignallingMessage) => {
+      expect(signal.type).toEqual('ERROR');
+      done();
+    });
+  });
+
+  it('onceConnected rejects if closed before negotiation', (done) => {
+    var bob = bridge.legacy();
+    bob.close();
+    bob.onceConnected.catch(done);
+  });
+
+  it('onceClosed fulfills if closed before negotiation', (done) => {
+    var bob = bridge.legacy();
+    bob.close();
+    bob.onceClosed.then(done);
+  });
+});

--- a/src/bridge/bridge.ts
+++ b/src/bridge/bridge.ts
@@ -14,16 +14,6 @@ var log :logging.Log = new logging.Log('bridge');
 // Static constructors.
 ////////
 
-// Creates a bridge which initiates with the best provider and will pair
-// with any of the provider types known to this bridge. Use this for
-// convenience or or when you will not be initiating.
-export var best = (
-    name?:string,
-    config?:freedom_RTCPeerConnection.RTCConfiguration)
-    :BridgingPeerConnection => {
-  return basicObfuscation(name, config);
-}
-
 // Use this if you think the remote peer supports bridging but
 // you don't want to use obfuscation.
 export var preObfuscation = (
@@ -40,6 +30,11 @@ export var basicObfuscation = (
     :BridgingPeerConnection => {
   return new BridgingPeerConnection(ProviderType.CHURN, name, config);
 }
+
+// Creates a bridge which initiates with the best provider and will pair
+// with any of the provider types known to this bridge. Use this for
+// convenience or or when you will not be initiating.
+export var best = basicObfuscation;
 
 ////////
 // Signalling messages (wire protocol).

--- a/src/bridge/bridge.ts
+++ b/src/bridge/bridge.ts
@@ -1,0 +1,425 @@
+/// <reference path='../../../third_party/typings/es6-promise/es6-promise.d.ts' />
+/// <reference path='../../../third_party/freedom-typings/freedom-common.d.ts' />
+
+import aggregate = require('../handler/aggregate');
+import churn = require('../churn/churn');
+import churn_types = require('../churn/churn.types');
+import handler = require('../handler/queue');
+import logging = require('../logging/logging');
+import peerconnection = require('../webrtc/peerconnection');
+import peerconnection_types = require('../webrtc/signals');
+
+var log :logging.Log = new logging.Log('bridge');
+
+////////
+// Static constructors.
+////////
+
+// Creates a bridge which initiates with the best provider and will pair
+// with any supported provider. Use this for convenience, or when you
+// will not be initiating.
+export var best = (
+    name?:string,
+    config?:freedom_RTCPeerConnection.RTCConfiguration)
+    :BridgingPeerConnection => {
+  return basicObfuscation(name, config);
+}
+
+// Creates a new bridge which only attempts legacy, non-obfuscated,
+// peerconnections.
+export var legacy = (
+    name?:string,
+    config?:freedom_RTCPeerConnection.RTCConfiguration)
+    :BridgingPeerConnection => {
+  return new BridgingPeerConnection(ProviderType.LEGACY, name, config);
+}
+
+// Creates a new bridge which attempts to speak obfuscation.
+// Use this if you think the remote peer supports it.
+export var basicObfuscation = (
+    name?:string,
+    config?:freedom_RTCPeerConnection.RTCConfiguration)
+    :BridgingPeerConnection => {
+  return new BridgingPeerConnection(ProviderType.CHURN, name, config);
+}
+
+////////
+// Signalling messages (wire protocol).
+////////
+
+// Wraps and batches the output of one or more concrete PeerConnection
+// providers. Generally, just one of these messages needs to be sent by each
+// peer in order to establish a connection. This is very useful in
+// copypaste-type scenarios.
+export interface SignallingMessage {
+  // Not actually read by this class but uProxy uses this as a hint
+  // one or two places.
+  type ?:string;
+  // All concrete PeerConnection providers offered by the peer.
+  // The remote bridge should select one, indicating its choice in the
+  // answer.
+  providers ?:Provider[];
+}
+
+// BridgingPeerConnection-specific message type.
+export enum SignallingMessageType {
+  OFFER,
+  ANSWER,
+  ERROR
+}
+
+// Encapsulates a batch of signalling messages from a concrete PeerConnection
+// provider. Generally, a batch of signalling messages will be sufficient to
+// establish a peerconnection with a peer.
+export interface Provider {
+  name ?:string;
+  signals ?:Object[];
+}
+
+////////
+// Static helper functions.
+////////
+
+// Constructs a signalling message suitable for the initial offer.
+// Public for testing.
+export var makeSingleProviderMessage = (
+    signalType:SignallingMessageType,
+    providerType:ProviderType,
+    signals:Object[]) : Provider => {
+  return {
+    type: SignallingMessageType[signalType],
+    providers: [
+      {
+        name: ProviderType[providerType],
+        signals: signals
+      }
+    ]
+  };
+}
+
+// Finds the first provider listed, throwing if none is found.
+// Public for testing.
+export var pickBestProvider = (
+    providers:Provider[]) : Provider => {
+  var legacy: Provider;
+  var churn: Provider;
+  for (var i = 0; i < providers.length; i++) {
+    var provider = providers[i];
+    if (provider.name === undefined) {
+      continue;
+    }
+    if (provider.name === ProviderType[ProviderType.LEGACY]) {
+      legacy = provider;
+    } else if (provider.name === ProviderType[ProviderType.CHURN]) {
+      churn = provider;
+    }
+  }
+  if (churn || legacy) {
+    return churn || legacy;
+  }
+  throw new Error('no supported provider found');
+}
+
+// Finds the requested provider, throwing if not found.
+var findProvider = (
+    type:ProviderType,
+    providers:Provider[]) : Provider => {
+  for (var i = 0; i < providers.length; i++) {
+    var provider = providers[i];
+    if (provider.name && provider.name === ProviderType[type]) {
+      return provider;
+    }
+  }
+  throw new Error('provider ' + ProviderType[type] + ' not found');
+}
+
+////////
+// Signalling message batching for concrete providers.
+////////
+
+// Public for testing.
+export class LegacySignalAggregator implements aggregate.Aggregator<
+    peerconnection_types.Message,
+    peerconnection_types.Message[]> {
+  private signals_ :peerconnection_types.Message[] = [];
+  private haveNoMoreCandidates_ = false;
+
+  public input = (signal:peerconnection_types.Message) => {
+    this.signals_.push(signal);
+    this.haveNoMoreCandidates_ = this.haveNoMoreCandidates_ || (
+        signal.type &&
+        signal.type === peerconnection_types.Type.NO_MORE_CANDIDATES);
+  }
+
+  public check = () => {
+    if (this.haveNoMoreCandidates_) {
+      var batch = this.signals_;
+      this.signals_ = [];
+      this.haveNoMoreCandidates_ = false;
+      return batch;
+    }
+    return null;
+  }
+}
+
+// Public for testing.
+export class ChurnSignalAggregator implements aggregate.Aggregator<
+    churn_types.ChurnSignallingMessage,
+    churn_types.ChurnSignallingMessage[]> {
+  private signals_ :churn_types.ChurnSignallingMessage[] = [];
+  private haveNoMoreCandidates_ = false;
+  private haveEndpoint_ = false;
+
+  public input = (signal:churn_types.ChurnSignallingMessage) => {
+    this.signals_.push(signal);
+    this.haveNoMoreCandidates_ = this.haveNoMoreCandidates_ || (
+        signal.webrtcMessage &&
+        signal.webrtcMessage.type &&
+        signal.webrtcMessage.type === peerconnection_types.Type.NO_MORE_CANDIDATES);
+    this.haveEndpoint_ = this.haveEndpoint_ ||
+        (signal.publicEndpoint !== undefined);
+  }
+
+  public check = () => {
+    if (this.haveNoMoreCandidates_ && this.haveEndpoint_) {
+      var batch = this.signals_;
+      this.signals_ = [];
+      this.haveNoMoreCandidates_ = false;
+      this.haveEndpoint_ = false;
+      return batch;
+    }
+    return null;
+  }
+}
+
+////////
+// The class itself.
+////////
+
+// Exported for constructor of exported class.
+export enum ProviderType {
+  LEGACY,
+  CHURN
+}
+
+enum BridgingState {
+  NEW,
+  INITIATING,
+  ANSWERING
+}
+
+// Establishes connectivity with the help of a variety of peerconnection
+// providers, batching signalling messages for the benefit of copypaste
+// scenarios.
+//
+// This early iteration has two key characteristics:
+//  - an offer includes *one* provider, its type chosen at construction time
+//  - to answer, *one* provider will be selected
+//
+// At some point in the future we will want to extend these messages, e.g.
+// including >1 provider in offers and describing the protocol between
+// SocksToRtc and RtcToNet. To preserve backwards compatibility, we should
+// strive to always support the initial offer case here, which will pick one
+// of the CHURN or LEGACY provider.
+//
+// TODO: Pass non-bridging signalling messages through, to support old clients.
+// TODO: Batching complicates a few things here and it's so useful that it
+//       probably should just be pushed up to the PeerConnection interface.
+export class BridgingPeerConnection implements peerconnection.PeerConnection<
+    SignallingMessage> {
+
+  // Number of instances created, for logging purposes.
+  private static id_ = 0;
+
+  // TODO: remove these public fields from the interface
+  public pcState :peerconnection.State;
+  public dataChannels :{[label:string] : peerconnection.DataChannel};
+
+  // This is hazily defined by the superclass: roughly, it fulfills when the
+  // peer has made or received an offer -- and there are several cases in which
+  // it never fulfills, e.g. close is called before connection is established.
+  // Here, it fulfills once a provider has been created, i.e.:
+  //  1. negotiateConnection is called
+  //  2. a *valid* offer is received
+  private connecting_ :() => void;
+  public onceConnecting: Promise<void> = new Promise<void>((F, R) => {
+    this.connecting_ = F;
+  });
+
+  // Equivalent to the negotiated provider's onceConnected field unless close
+  // is called before negotiation happens, in which case it rejects immediately.
+  private connected_ :() => void;
+  private rejectConnected_ :(e:Error) => void;
+  public onceConnected :Promise<void> = new Promise<void>((F, R) => {
+    this.connected_ = F;
+    this.rejectConnected_ = R;
+  });
+
+  // Equivalent to the negotiated provider's onceConnected field unless close
+  // is called before negotiation happens, in which case this fulfills
+  // immediately.
+  private closed_ :() => void;
+  public onceClosed :Promise<void> = new Promise<void>((F, R) => {
+    this.closed_ = F;
+  });
+
+  public peerOpenedChannelQueue =
+      new handler.Queue<peerconnection.DataChannel, void>();
+
+  public signalForPeerQueue =
+      new handler.Queue<SignallingMessage, void>();
+
+  // Negotiated, actual, provider type.
+  private providerType_: ProviderType;
+
+  private provider_ :peerconnection.PeerConnection<any>;
+
+  private state_: BridgingState = BridgingState.NEW;
+
+  // Private, use the static constructors instead.
+  constructor(
+      private preferredProviderType_ :ProviderType,
+      private name_ :string = 'unnamed-bridge-' + BridgingPeerConnection.id_,
+      private config_ ?:freedom_RTCPeerConnection.RTCConfiguration) {
+    BridgingPeerConnection.id_++;
+
+    // Some logging niceties.
+    this.onceConnecting.then(() => {
+      log.debug('%1: now bridging (current state: %2)',
+          this.name_, BridgingState[this.state_]);
+    });
+  }
+
+  public negotiateConnection = () : Promise<void> => {
+    log.debug('%1: negotiating, offering %2 provider',
+        this.name_, ProviderType[this.preferredProviderType_]);
+    this.state_ = BridgingState.INITIATING;
+    this.bridgeWith_(
+        this.preferredProviderType_,
+        this.makeFromProviderType_(this.preferredProviderType_));
+    return this.provider_.negotiateConnection();
+  }
+
+  private makeFromProviderType_ = (
+      type:ProviderType) : peerconnection.PeerConnection<any> => {
+    if (type !== ProviderType.LEGACY && type !== ProviderType.CHURN) {
+      throw new Error('unknown provider type ' + type);
+    }
+
+    var pc :freedom_RTCPeerConnection.RTCPeerConnection =
+        freedom['core.rtcpeerconnection'](this.config_);
+    return type === ProviderType.LEGACY ?
+        this.makeLegacy_(pc) :
+        this.makeChurn_(pc);
+  }
+
+  // Factored out for mocking purposes.
+  private makeLegacy_ = (
+      pc:freedom_RTCPeerConnection.RTCPeerConnection)
+      : peerconnection.PeerConnection<peerconnection_types.Message> => {
+    log.debug('%1: constructing legacy peerconnection', this.name_);
+    return new peerconnection.PeerConnectionClass(pc, this.name_);
+  }
+
+  // Factored out for mocking purposes.
+  private makeChurn_ = (
+      pc:freedom_RTCPeerConnection.RTCPeerConnection)
+      : peerconnection.PeerConnection<churn_types.ChurnSignallingMessage> => {
+    log.debug('%1: constructing churn peerconnection', this.name_);
+    return new churn.Connection(pc, this.name_);
+  }
+
+  // Configures the bridge with this provider by establishing setting queue
+  // forwarding, signal batching, and fulfilling onceBridging_.
+  // State is *not* set here: that depends on whether we're initiating or
+  // answering.
+  private bridgeWith_ = (
+      providerType:ProviderType,
+      provider:peerconnection.PeerConnection<Object>) : void => {
+    var batcher = aggregate.createAggregateHandler(
+        this.makeBatcher_(providerType));
+    batcher.nextAggregate().then((batchedSignals) => {
+      this.signalForPeerQueue.handle(makeSingleProviderMessage(
+          this.state_ === BridgingState.INITIATING ?
+              SignallingMessageType.OFFER :
+              SignallingMessageType.ANSWER,
+          providerType,
+          batchedSignals));
+    });
+    provider.signalForPeerQueue.setSyncHandler(batcher.handle);
+
+    // Forward new channel queue.
+    provider.peerOpenedChannelQueue.setHandler(
+        this.peerOpenedChannelQueue.handle);
+
+    // Forward promises.
+    provider.onceConnected.then(this.connected_, this.rejectConnected_);
+    provider.onceClosed.then(this.closed_);
+
+    this.providerType_ = providerType;
+    this.provider_ = provider;
+
+    this.connecting_();
+  }
+
+  private makeBatcher_ = (type:ProviderType): aggregate.Aggregator<
+      Object, Object[]> => {
+    if (type !== ProviderType.LEGACY && type !== ProviderType.CHURN) {
+      throw new Error('unknown provider type');
+    }
+    return type === ProviderType.LEGACY ?
+        new LegacySignalAggregator() :
+        new ChurnSignalAggregator();    
+  }
+
+  // Unbatches the signals and forwards them to the current provider,
+  // first creating a provider if necessary.
+  public handleSignalMessage = (
+      message:SignallingMessage) : void => {
+    log.debug('%1: handling signal: %2', this.name_, message);
+
+    try {
+      var provider: Provider;
+      if (this.state_ === BridgingState.NEW) {
+        provider = pickBestProvider(message.providers);
+        var providerType = (<any>ProviderType)[provider.name];
+        log.debug('%1: received offer, responding with %2 provider',
+            this.name_, ProviderType[providerType]);
+        this.state_ = BridgingState.ANSWERING;
+        this.bridgeWith_(
+            providerType,
+            this.makeFromProviderType_(providerType));
+      } else {
+        provider = findProvider(this.providerType_, message.providers);
+      }
+
+      // Unbatch the signals and forward to the provider.
+      for (var i = 0; i < provider.signals.length; i++) {
+        var signal = provider.signals[i];
+        log.debug('%1: unbatched signal: %2', this.name_, signal);
+        this.provider_.handleSignalMessage(signal);
+      }
+    } catch (e) {
+      this.signalForPeerQueue.handle({
+        type: SignallingMessageType[
+            SignallingMessageType.ERROR]
+      });
+    }
+  }
+
+  public openDataChannel = (channelLabel:string,
+      options?:freedom_RTCPeerConnection.RTCDataChannelInit)
+      : Promise<peerconnection.DataChannel> => {
+    return this.provider_.openDataChannel(channelLabel, options);
+  }
+
+  public close = () : Promise<void> => {
+    if (this.state_ === BridgingState.NEW) {
+      this.rejectConnected_(new Error('closed before negotiation succeeded'));
+      this.closed_();
+    } else {
+      this.provider_.close();
+    }
+    return this.onceClosed;
+  }
+}

--- a/src/bridge/bridge.ts
+++ b/src/bridge/bridge.ts
@@ -1,7 +1,6 @@
 /// <reference path='../../../third_party/typings/es6-promise/es6-promise.d.ts' />
 /// <reference path='../../../third_party/freedom-typings/freedom-common.d.ts' />
 
-import aggregate = require('../handler/aggregate');
 import churn = require('../churn/churn');
 import churn_types = require('../churn/churn.types');
 import handler = require('../handler/queue');

--- a/src/bridge/bridge.ts
+++ b/src/bridge/bridge.ts
@@ -286,11 +286,7 @@ export class BridgingPeerConnection implements peerconnection.PeerConnection<
       }
 
       // Unbatch the signals and forward to the provider.
-      for (var i = 0; i < provider.signals.length; i++) {
-        var signal = provider.signals[i];
-        log.debug('%1: unbatched signal: %2', this.name_, signal);
-        this.provider_.handleSignalMessage(signal);
-      }
+      provider.signals.forEach(this.provider_.handleSignalMessage);
     } catch (e) {
       this.signalForPeerQueue.handle({
         errorOnLastMessage: true

--- a/src/bridge/bridge.ts
+++ b/src/bridge/bridge.ts
@@ -31,9 +31,9 @@ export var basicObfuscation = (
   return new BridgingPeerConnection(ProviderType.CHURN, name, config);
 }
 
-// Creates a bridge which initiates with the best provider and will pair
-// with any of the provider types known to this bridge. Use this for
-// convenience or or when you will not be initiating.
+// Creates a bridge which initiates with the best provider and can
+// accept an offer from any of the provider types known to this
+// bridge. Use this for convenience or or when you will not be initiating.
 export var best = basicObfuscation;
 
 ////////

--- a/src/bridge/bridge.ts
+++ b/src/bridge/bridge.ts
@@ -15,8 +15,8 @@ var log :logging.Log = new logging.Log('bridge');
 ////////
 
 // Creates a bridge which initiates with the best provider and will pair
-// with any supported provider. Use this for convenience, or when you
-// will not be initiating.
+// with any of the provider types known to this bridge. Use this for
+// convenience or or when you will not be initiating.
 export var best = (
     name?:string,
     config?:freedom_RTCPeerConnection.RTCConfiguration)

--- a/src/bridge/bridge.ts
+++ b/src/bridge/bridge.ts
@@ -304,7 +304,7 @@ export class BridgingPeerConnection implements peerconnection.PeerConnection<
     return new churn.Connection(pc, this.name_);
   }
 
-  // Configures the bridge with this provider by establishing setting queue
+  // Configures the bridge with this provider by establishing queue
   // forwarding, signal batching, and fulfilling onceBridging_.
   // State is *not* set here: that depends on whether we're initiating or
   // answering.

--- a/src/integration-tests/socks-echo/proxy-integration-test.ts
+++ b/src/integration-tests/socks-echo/proxy-integration-test.ts
@@ -74,7 +74,7 @@ class AbstractProxyIntegrationTest implements ProxyIntegrationTester {
 
     this.socksToRtc_ = new socks_to_rtc.SocksToRtc();
     this.rtcToNet_ = new rtc_to_net.RtcToNet();
-    this.rtcToNet_.startFromConfig(rtcToNetProxyConfig,rtcPcConfig,obfuscate);
+    this.rtcToNet_.startFromConfig(rtcToNetProxyConfig, rtcPcConfig);
     this.rtcToNet_.signalsForPeer.setSyncHandler(this.socksToRtc_.handleSignalFromPeer);
     this.socksToRtc_.on('signalForPeer', this.rtcToNet_.handleSignalFromPeer);
     return this.socksToRtc_.startFromConfig(socksToRtcEndpoint, rtcPcConfig, obfuscate);

--- a/src/samples/copypaste-socks-chromeapp/freedom-module.ts
+++ b/src/samples/copypaste-socks-chromeapp/freedom-module.ts
@@ -160,7 +160,7 @@ var doStart = () => {
   socksRtc.startFromConfig(
       localhostEndpoint,
       pcConfig,
-      false) // obfuscate
+      false) // initiate with obfuscation
     .then((endpoint:net.Endpoint) => {
       log.info('socksRtc ready. listening to SOCKS5 on: ' + JSON.stringify(endpoint));
       log.info('` curl -x socks5h://localhost:9999 www.google.com `')

--- a/src/samples/copypaste-socks-chromeapp/freedom-module.ts
+++ b/src/samples/copypaste-socks-chromeapp/freedom-module.ts
@@ -9,6 +9,7 @@ import socks_to_rtc = require('../../socks-to-rtc/socks-to-rtc');
 import net = require('../../net/net.types');
 import tcp = require('../../net/tcp');
 import signals = require('../../webrtc/signals');
+import bridge = require('../../bridge/bridge');
 
 import logging = require('../../logging/logging');
 import loggingTypes = require('../../loggingprovider/loggingprovider.types');
@@ -18,14 +19,9 @@ import loggingTypes = require('../../loggingprovider/loggingprovider.types');
 // warnings by default from the rest of the system.  Note that the proxy is
 // extremely slow in debug mode.
 var loggingController = freedom['loggingcontroller']();
-
-loggingController.setDefaultFilter(loggingTypes.Destination.console,
-                                   loggingTypes.Level.info);
-
-loggingController.setFilters(loggingTypes.Destination.console, {
-  'SocksToRtc': loggingTypes.Level.info,
-  'RtcToNet': loggingTypes.Level.info
-});
+loggingController.setDefaultFilter(
+    loggingTypes.Destination.console,
+    loggingTypes.Level.debug);
 
 var log :logging.Log = new logging.Log('copypaste-socks');
 
@@ -188,10 +184,9 @@ parentModule.on('handleSignalMessage', (message:signals.Message) => {
   } else {
     if (rtcNet === undefined) {
       rtcNet = new rtc_to_net.RtcToNet();
-      rtcNet.startFromConfig(
-          { allowNonUnicast:true },
-          pcConfig,
-          false); // obfuscate
+      rtcNet.startFromConfig({
+        allowNonUnicast:true
+      }, pcConfig);
       log.info('created rtc-to-net');
 
       // Forward signalling channel messages to the UI.

--- a/src/samples/copypaste-socks-chromeapp/main.core-env.ts
+++ b/src/samples/copypaste-socks-chromeapp/main.core-env.ts
@@ -22,18 +22,16 @@ module copypaste_module {
     copypaste.on('signalForPeer', (message:signals.Message) => {
       model.readyForStep2 = true;
 
-      // Append the new signalling message to the previous message(s), if any.
-      // Base64-encode the concatenated messages because some communication
+      // Base64-encode the signalling message because some communication
       // channels are likely to transform portions of the raw concatenated JSON
       // into emoticons, whereas the base64 alphabet is much less prone to such
       // unintended transformation.
-      var oldConcatenatedJson = base64Decode(model.outboundMessageValue.trim());
-      var newConcatenatedJson = oldConcatenatedJson + '\n' + JSON.stringify(message);
+      var messageAsJson = JSON.stringify(message);
       if (model.usingCrypto) {
         copypaste.emit('friendKey', model.friendPublicKey);
-        copypaste.emit('signEncrypt', base64Encode(newConcatenatedJson));
+        copypaste.emit('signEncrypt', base64Encode(messageAsJson));
       }
-      model.outboundMessageValue = base64Encode(newConcatenatedJson);
+      model.outboundMessageValue = base64Encode(messageAsJson);
     });
 
     copypaste.on('gotPeerSDP', (peerSDP:string) => {
@@ -119,10 +117,9 @@ module copypaste_module {
     totalBytesSent : 0
   };
 
-  // Stores the parsed messages for use later, if & when the user clicks the
+  // Stores the parsed message for use later, if & when the user clicks the
   // button for consuming the messages.
-  var parsedInboundMessages :signals.Message[];
-
+  var parsedInboundMessage: Object;
 
   // Define basee64 helper functions that are type-annotated and meaningfully
   // named.
@@ -139,43 +136,16 @@ module copypaste_module {
   // signalling messages. Enables/disables the corresponding form button, as
   // appropriate. Returns null if the field contents are malformed.
   export function parseInboundMessages(inboundMessageFieldValue:string) : void {
-    // Base64-decode the pasted text.
-    var signalsString :string = null;
     try {
-      signalsString = base64Decode(inboundMessageFieldValue.trim());
-    } catch (e) {
-      // TODO: Notify the user that the pasted text is malformed.
-      return null;
-    }
+      // Decode and de-deserialise the pasted text.
+      var messageJson = base64Decode(inboundMessageFieldValue.trim());
+      parsedInboundMessage = JSON.parse(messageJson);
 
-    var signals :string[] = signalsString.trim().split('\n');
-
-    // Each line should be a JSON representation of a signals.Message.
-    // Parse the lines here.
-    var parsedSignals :signals.Message[] = [];
-    for (var i = 0; i < signals.length; i++) {
-      var s :string = signals[i].trim();
-
-      // TODO: Consider detecting the error if the text is well-formed JSON but
-      // does not represent a signals.Message.
-      var message :signals.Message;
-      try {
-        message = JSON.parse(s);
-      } catch (e) {
-        parsedSignals = null;
-        break;
-      }
-      parsedSignals.push(message);
-    }
-
-    // Enable/disable, as appropriate, the button for consuming the messages.
-    if (null !== parsedSignals && parsedSignals.length > 0) {
+      // Enable the button for consuming the messages.
       model.inputIsWellFormed = true;
-    } else {
-      // TODO: Notify the user that the pasted text is malformed.
+    } catch (e) {
+      console.warn('cannot parse message: ' + e.message);
     }
-
-    parsedInboundMessages = parsedSignals;
   }
 
   // Forwards each line from the paste box to the Freedom app, which
@@ -185,9 +155,7 @@ module copypaste_module {
   export function consumeInboundMessage() : void {
     // Forward the signalling messages to the Freedom app.
     onceReady.then(function(copypaste) {
-      for (var i = 0; i < parsedInboundMessages.length; i++) {
-        copypaste.emit('handleSignalMessage', parsedInboundMessages[i]);
-      }
+      copypaste.emit('handleSignalMessage', parsedInboundMessage);
     });
     model.proxyingState = 'connecting';
     // TODO: Report success/failure to the user.

--- a/src/samples/copypaste-socks-chromeapp/main.core-env.ts
+++ b/src/samples/copypaste-socks-chromeapp/main.core-env.ts
@@ -137,7 +137,7 @@ module copypaste_module {
   // appropriate. Returns null if the field contents are malformed.
   export function parseInboundMessages(inboundMessageFieldValue:string) : void {
     try {
-      // Decode and de-deserialise the pasted text.
+      // Decode and de-serialise the pasted text.
       var messageJson = base64Decode(inboundMessageFieldValue.trim());
       parsedInboundMessage = JSON.parse(messageJson);
 

--- a/src/samples/copypaste-socks-chromeapp/main.core-env.ts
+++ b/src/samples/copypaste-socks-chromeapp/main.core-env.ts
@@ -22,16 +22,18 @@ module copypaste_module {
     copypaste.on('signalForPeer', (message:signals.Message) => {
       model.readyForStep2 = true;
 
-      // Base64-encode the signalling message because some communication
+      // Append the new signalling message to the previous message(s), if any.
+      // Base64-encode the concatenated messages because some communication
       // channels are likely to transform portions of the raw concatenated JSON
       // into emoticons, whereas the base64 alphabet is much less prone to such
       // unintended transformation.
-      var messageAsJson = JSON.stringify(message);
+      var oldConcatenatedJson = base64Decode(model.outboundMessageValue.trim());
+      var newConcatenatedJson = oldConcatenatedJson + '\n' + JSON.stringify(message);
       if (model.usingCrypto) {
         copypaste.emit('friendKey', model.friendPublicKey);
-        copypaste.emit('signEncrypt', base64Encode(messageAsJson));
+        copypaste.emit('signEncrypt', base64Encode(newConcatenatedJson));
       }
-      model.outboundMessageValue = base64Encode(messageAsJson);
+      model.outboundMessageValue = base64Encode(newConcatenatedJson);
     });
 
     copypaste.on('gotPeerSDP', (peerSDP:string) => {
@@ -117,9 +119,10 @@ module copypaste_module {
     totalBytesSent : 0
   };
 
-  // Stores the parsed message for use later, if & when the user clicks the
+  // Stores the parsed messages for use later, if & when the user clicks the
   // button for consuming the messages.
-  var parsedInboundMessage: Object;
+  var parsedInboundMessages :signals.Message[];
+
 
   // Define basee64 helper functions that are type-annotated and meaningfully
   // named.
@@ -136,16 +139,43 @@ module copypaste_module {
   // signalling messages. Enables/disables the corresponding form button, as
   // appropriate. Returns null if the field contents are malformed.
   export function parseInboundMessages(inboundMessageFieldValue:string) : void {
+    // Base64-decode the pasted text.
+    var signalsString :string = null;
     try {
-      // Decode and de-serialise the pasted text.
-      var messageJson = base64Decode(inboundMessageFieldValue.trim());
-      parsedInboundMessage = JSON.parse(messageJson);
-
-      // Enable the button for consuming the messages.
-      model.inputIsWellFormed = true;
+      signalsString = base64Decode(inboundMessageFieldValue.trim());
     } catch (e) {
-      console.warn('cannot parse message: ' + e.message);
+      // TODO: Notify the user that the pasted text is malformed.
+      return null;
     }
+
+    var signals :string[] = signalsString.trim().split('\n');
+
+    // Each line should be a JSON representation of a signals.Message.
+    // Parse the lines here.
+    var parsedSignals :signals.Message[] = [];
+    for (var i = 0; i < signals.length; i++) {
+      var s :string = signals[i].trim();
+
+      // TODO: Consider detecting the error if the text is well-formed JSON but
+      // does not represent a signals.Message.
+      var message :signals.Message;
+      try {
+        message = JSON.parse(s);
+      } catch (e) {
+        parsedSignals = null;
+        break;
+      }
+      parsedSignals.push(message);
+    }
+
+    // Enable/disable, as appropriate, the button for consuming the messages.
+    if (null !== parsedSignals && parsedSignals.length > 0) {
+      model.inputIsWellFormed = true;
+    } else {
+      // TODO: Notify the user that the pasted text is malformed.
+    }
+
+    parsedInboundMessages = parsedSignals;
   }
 
   // Forwards each line from the paste box to the Freedom app, which
@@ -155,7 +185,9 @@ module copypaste_module {
   export function consumeInboundMessage() : void {
     // Forward the signalling messages to the Freedom app.
     onceReady.then(function(copypaste) {
-      copypaste.emit('handleSignalMessage', parsedInboundMessage);
+      for (var i = 0; i < parsedInboundMessages.length; i++) {
+        copypaste.emit('handleSignalMessage', parsedInboundMessages[i]);
+      }
     });
     model.proxyingState = 'connecting';
     // TODO: Report success/failure to the user.

--- a/src/simple-socks/freedom-module.ts
+++ b/src/simple-socks/freedom-module.ts
@@ -31,7 +31,7 @@ var pcConfig :freedom_RTCPeerConnection.RTCConfiguration = {
 };
 
 export var rtcNet = new rtc_to_net.RtcToNet();
-rtcNet.startFromConfig({ allowNonUnicast: true }, pcConfig, false); // obfuscate
+rtcNet.startFromConfig({ allowNonUnicast: true }, pcConfig); // obfuscate
 
 //-----------------------------------------------------------------------------
 export var socksRtc = new socks_to_rtc.SocksToRtc();

--- a/src/simple-socks/freedom-module.ts
+++ b/src/simple-socks/freedom-module.ts
@@ -31,7 +31,7 @@ var pcConfig :freedom_RTCPeerConnection.RTCConfiguration = {
 };
 
 export var rtcNet = new rtc_to_net.RtcToNet();
-rtcNet.startFromConfig({ allowNonUnicast: true }, pcConfig); // obfuscate
+rtcNet.startFromConfig({ allowNonUnicast: true }, pcConfig);
 
 //-----------------------------------------------------------------------------
 export var socksRtc = new socks_to_rtc.SocksToRtc();

--- a/src/simple-socks/freedom-module.ts
+++ b/src/simple-socks/freedom-module.ts
@@ -39,7 +39,7 @@ socksRtc.on('signalForPeer', rtcNet.handleSignalFromPeer);
 socksRtc.startFromConfig(
     localhostEndpoint,
     pcConfig,
-    false) // obfuscate
+    false) // initiate with obfuscation
   .then((endpoint:net.Endpoint) => {
     log.info('SocksToRtc listening on: ' + JSON.stringify(endpoint));
     log.info('curl -x socks5h://' + endpoint.address + ':' + endpoint.port +

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -97,6 +97,10 @@ module SocksToRtc {
     // returned within the promise's endpoint).
     // NOTE: Users of this class MUST add on-event listeners before calling
     //       this method.
+    // NOTE: The arguments here are likely to change as more PeerConnection
+    //       providers and options are added; for now, setting obfuscate to
+    //       true implies the basicObfuscation bridge while false implies
+    //       preObfuscation.
     public startFromConfig = (
         localSocksServerEndpoint:net.Endpoint,
         config:freedom_RTCPeerConnection.RTCConfiguration,

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -105,7 +105,7 @@ module SocksToRtc {
           new tcp.Server(localSocksServerEndpoint),
           obfuscate ?
             bridge.basicObfuscation('sockstortc', config) :
-            bridge.legacy('sockstortc', config));
+            bridge.preObfuscation('sockstortc', config));
     }
 
     // Starts the SOCKS server with the supplied TCP server and peerconnection.

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -4,10 +4,9 @@
 
 import arraybuffers = require('../arraybuffers/arraybuffers');
 import peerconnection = require('../webrtc/peerconnection');
-import signals = require('../webrtc/signals');
 import handler = require('../handler/queue');
 
-import churn = require('../churn/churn');
+import bridge = require('../bridge/bridge');
 import net = require('../net/net.types');
 import tcp = require('../net/tcp');
 import socks = require('../socks-common/socks-headers');
@@ -63,8 +62,7 @@ module SocksToRtc {
 
     // The connection to the peer that is acting as the endpoint for the proxy
     // connection.
-    private peerConnection_
-        :peerconnection.PeerConnection<signals.Message>;
+    private peerConnection_ :peerconnection.PeerConnection<Object>;
 
     // This pool manages the PeerConnection's datachannels.
     private pool_ : Pool;
@@ -93,22 +91,21 @@ module SocksToRtc {
       }
     }
 
-    // Handles creation of a TCP server and peerconnection. Returns the endpoint
-    // it ended up listening on (if |localSocksServerEndpoint| has port set to
-    // 0, then a dynamic port is allocated and this port is returned within the
-    // promise's endpoint).  NOTE: Users of this class MUST add on-event
-    // listeners before calling this method.
+    // Handles creation of a TCP server and bridging peerconnection. Returns
+    // the endpoint it ended up listening on (if |localSocksServerEndpoint|
+    // has port set to 0 then a dynamic port is allocated and this port is
+    // returned within the promise's endpoint).
+    // NOTE: Users of this class MUST add on-event listeners before calling
+    //       this method.
     public startFromConfig = (
         localSocksServerEndpoint:net.Endpoint,
-        pcConfig:freedom_RTCPeerConnection.RTCConfiguration,
+        config:freedom_RTCPeerConnection.RTCConfiguration,
         obfuscate?:boolean) : Promise<net.Endpoint> => {
-      var pc :freedom_RTCPeerConnection.RTCPeerConnection =
-          freedom['core.rtcpeerconnection'](pcConfig);
       return this.start(
           new tcp.Server(localSocksServerEndpoint),
           obfuscate ?
-              new churn.Connection(pc, 'SocksToRtc') :
-              new peerconnection.PeerConnectionClass(pc));
+            bridge.basicObfuscation('sockstortc', config) :
+            bridge.legacy('sockstortc', config));
     }
 
     // Starts the SOCKS server with the supplied TCP server and peerconnection.
@@ -116,9 +113,7 @@ module SocksToRtc {
     // method is public only for testing purposes.
     public start = (
         tcpServer:tcp.Server,
-        // TODO(iislucas): are the types correct here? Does an obfuscated
-        // channel have a different signalling type?
-        peerconnection:peerconnection.PeerConnection<signals.Message>)
+        peerconnection:peerconnection.PeerConnection<Object>)
         : Promise<net.Endpoint> => {
       if (this.tcpServer_) {
         throw new Error('already configured');
@@ -240,8 +235,7 @@ module SocksToRtc {
       });
     }
 
-    public handleSignalFromPeer = (signal:signals.Message)
-        : void => {
+    public handleSignalFromPeer = (signal:Object) : void => {
       this.peerConnection_.handleSignalMessage(signal);
     }
 


### PR DESCRIPTION
Roughly, this implements the proposal from the associated issue:
https://github.com/uProxy/uproxy/issues/1433

There is a bunch of stuff concerning batching of signalling messages but, really, the key part of all this is `BridgingPeerConnection.handleSignalMessage` which looks for a supported provider in the signalling message and answers accordingly. I think studying that along with the signalling messages definitions should explain all this. I'd be very interested to discuss a likely scenario you think this can't support.

An immediate followup will be to "pass through" legacy signalling messages, to support older clients. As we've discussed, it's not worth going to the trouble of supporting old one-time connections.

Tested with the sample apps and with uProxy; in-progress switchover here (I haven't touched one-time connections yet):
https://github.com/uProxy/uproxy/compare/trevj-bridge?expand=1

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/178)

<!-- Reviewable:end -->
