### PR TITLE
simple socks should not specify STUN servers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "27.1.0",
+  "version": "27.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"

--- a/src/samples/simple-churn-chat-chromeapp/freedom-module.ts
+++ b/src/samples/simple-churn-chat-chromeapp/freedom-module.ts
@@ -50,9 +50,7 @@ function connectDataChannel(name:string, d:DataChannel) {
 // Make a peer connection which logs stuff that happens.
 function makePeerConnection(name:string) {
   var pcConfig :freedom_RTCPeerConnection.RTCConfiguration = {
-    iceServers: [{
-      urls: ['stun:stun.l.google.com:19302']},
-      {urls: ['stun:stun1.l.google.com:19302']}]
+    iceServers: []
   };
   var pc :PeerConnection<churn_types.ChurnSignallingMessage> =
       new churn.Connection(freedom['core.rtcpeerconnection'](pcConfig),

--- a/src/simple-socks/freedom-module.ts
+++ b/src/simple-socks/freedom-module.ts
@@ -25,9 +25,11 @@ loggingController.setDefaultFilter(loggingTypes.Destination.console,
 var localhostEndpoint:net.Endpoint = { address: '127.0.0.1', port:9999 };
 
 //-----------------------------------------------------------------------------
+// Don't specify STUN servers because they aren't needed and can, in fact,
+// present a problem when Simple SOCKS is running on a system behind a NAT
+// without support for hair-pinning.
 var pcConfig :freedom_RTCPeerConnection.RTCConfiguration = {
-  iceServers: [{urls: ['stun:stun.l.google.com:19302']},
-               {urls: ['stun:stun1.l.google.com:19302']}]
+  iceServers: []
 };
 
 export var rtcNet = new rtc_to_net.RtcToNet();


### PR DESCRIPTION
Works around for this issue (also, there is just no need for these samples to specify STUN servers):
https://github.com/uProxy/uproxy/issues/1591

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/184)

<!-- Reviewable:end -->
