### PR TITLE
fallback to Math.random for key generation on firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "27.1.1",
+  "version": "27.1.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"

--- a/src/churn/churn.ts
+++ b/src/churn/churn.ts
@@ -174,7 +174,7 @@ var log :logging.Log = new logging.Log('churn');
   // Generates a key suitable for use with CaesarCipher, viz. 1-255.
   var generateCaesarKey_ = (): number => {
     try {
-      return (random.randomUint32() % 254) + 1;
+      return (random.randomUint32() % 255) + 1;
     } catch (e) {
       // https://github.com/uProxy/uproxy/issues/1593
       log.debug('crypto unavailable, using Math.random');

--- a/src/churn/churn.ts
+++ b/src/churn/churn.ts
@@ -172,8 +172,14 @@ var log :logging.Log = new logging.Log('churn');
   };
 
   // Generates a key suitable for use with CaesarCipher, viz. 1-255.
-  var generateCaesarKey_ = () : number => {
-    return (random.randomUint32() % 254) + 1;
+  var generateCaesarKey_ = (): number => {
+    try {
+      return (random.randomUint32() % 254) + 1;
+    } catch (e) {
+      // https://github.com/uProxy/uproxy/issues/1593
+      log.debug('crypto unavailable, using Math.random');
+      return Math.floor((Math.random() * 255)) + 1;
+    }
   }
 
   /**


### PR DESCRIPTION
churn has some issues on Firefox. This is the easy fix, working around this issue:
https://github.com/uProxy/uproxy/issues/1593

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/185)

<!-- Reviewable:end -->
