### PR TITLE
remove pcState and dataChannels public fields from PeerConnection interface

### DIFF
--- a/src/bridge/bridge.ts
+++ b/src/bridge/bridge.ts
@@ -117,10 +117,6 @@ export class BridgingPeerConnection implements peerconnection.PeerConnection<
   // Number of instances created, for logging purposes.
   private static id_ = 0;
 
-  // TODO: remove these public fields from the interface
-  public pcState :peerconnection.State;
-  public dataChannels :{[label:string] : peerconnection.DataChannel};
-
   // This is hazily defined by the superclass: roughly, it fulfills when the
   // peer has made or received an offer -- and there are several cases in which
   // it never fulfills, e.g. close is called before connection is established.

--- a/src/churn/churn.ts
+++ b/src/churn/churn.ts
@@ -421,12 +421,6 @@ var log :logging.Log = new logging.Log('churn');
         };
         this.signalForPeerQueue.handle(churnSignal);
       });
-      // NOTE: Replacing |this.dataChannels| in this way breaks recursive nesting.
-      // If the caller or |obfuscatedConnection_| applies the same approach,
-      // the code will break in hard-to-debug fashion.  This could be
-      // addressed by using a javascript "getter", or by changing the
-      // peerconnection.PeerConnection API.
-      this.dataChannels = this.obfuscatedConnection_.dataChannels;
       this.peerOpenedChannelQueue =
           this.obfuscatedConnection_.peerOpenedChannelQueue;
     }

--- a/src/churn/churn.ts
+++ b/src/churn/churn.ts
@@ -201,8 +201,6 @@ var log :logging.Log = new logging.Log('churn');
    */
   export class Connection implements peerconnection.PeerConnection<ChurnSignallingMessage> {
 
-    public pcState :peerconnection.State;
-    public dataChannels :{[channelLabel:string] : peerconnection.DataChannel};
     public peerOpenedChannelQueue :handler.QueueHandler<peerconnection.DataChannel, void>;
     public signalForPeerQueue :handler.Queue<ChurnSignallingMessage, void>;
     public peerName :string;
@@ -290,17 +288,10 @@ var log :logging.Log = new logging.Log('churn');
         this.configurePipe_(answers[0], answers[1], answers[2], answers[3]);
       });
 
-      // Handle |pcState| and related promises.
-      this.pcState = peerconnection.State.WAITING;
-      this.onceConnecting = this.obfuscatedConnection_.onceConnecting.then(
-          () => {
-        this.pcState = peerconnection.State.CONNECTING;
-      });
-      this.onceConnected = this.obfuscatedConnection_.onceConnected.then(() => {
-        this.pcState = peerconnection.State.CONNECTED;
-      });
-      this.onceClosed = this.obfuscatedConnection_.onceClosed.then(
-          () => { this.pcState = peerconnection.State.CLOSED; });
+      // Forward onceXxx promises.
+      this.onceConnecting = this.obfuscatedConnection_.onceConnecting;
+      this.onceConnected = this.obfuscatedConnection_.onceConnected;
+      this.onceClosed = this.obfuscatedConnection_.onceClosed;
 
       // Debugging.
       this.onceProbingComplete_.then((endpoint:NatPair) => {

--- a/src/webrtc/peerconnection.ts
+++ b/src/webrtc/peerconnection.ts
@@ -24,15 +24,6 @@ export enum State {
 }
 
 export interface PeerConnection<TSignallingMessage> {
-  // The state of this peer connection.
-  pcState :State;
-
-  // All open data channels.
-  // NOTE: There exists a bug in Chrome prior to version 37 which causes
-  //       entries in this object to continue to exist even after
-  //       the remote peer has closed a data channel.
-  dataChannels     :{[channelLabel:string] : DataChannel};
-
   // The |onceConnecting| promise is fulfilled when |pcState === CONNECTING|.
   // i.e. when either |handleSignalMessage| is called with an offer message,
   // or when |negotiateConnection| is called. The promise is never be rejected


### PR DESCRIPTION
Addresses:
https://github.com/uProxy/uproxy/issues/583

Tested with Simple SOCKS and by compiling uProxy against my client; these fields aren't used anywhere.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/188)

<!-- Reviewable:end -->
