### PR TITLE
remove onceConnecting public field

### DIFF
--- a/src/bridge/bridge.spec.ts
+++ b/src/bridge/bridge.spec.ts
@@ -158,27 +158,6 @@ describe('BridgingPeerConnection', function() {
     });
   });
 
-  it('onceConnecting fulfills when negotiateConnection called', (done) => {
-    var bob = bridge.best();
-    bob.negotiateConnection();
-    bob.onceConnecting.then(done);
-  });
-
-  it('onceConnecting fulfills when valid offer received', (done) => {
-    var bob = bridge.best();
-    bob.handleSignalMessage({
-      type: 'OFFER',
-      signals: {
-        'PLAIN': [
-          offerSignal,
-          candidateSignal1,
-          noMoreCandidatesSignal
-        ]
-      }
-    });
-    bob.onceConnecting.then(done);
-  });
-
   it('rejects offer from unknown provider', (done) => {
     var bob = bridge.best();
     bob.handleSignalMessage({

--- a/src/churn/churn.ts
+++ b/src/churn/churn.ts
@@ -205,7 +205,6 @@ var log :logging.Log = new logging.Log('churn');
     public signalForPeerQueue :handler.Queue<ChurnSignallingMessage, void>;
     public peerName :string;
 
-    public onceConnecting :Promise<void>;
     public onceConnected :Promise<void>;
     public onceClosed :Promise<void>;
 
@@ -289,7 +288,6 @@ var log :logging.Log = new logging.Log('churn');
       });
 
       // Forward onceXxx promises.
-      this.onceConnecting = this.obfuscatedConnection_.onceConnecting;
       this.onceConnected = this.obfuscatedConnection_.onceConnected;
       this.onceClosed = this.obfuscatedConnection_.onceClosed;
 

--- a/src/rtc-to-net/rtc-to-net.spec.ts
+++ b/src/rtc-to-net/rtc-to-net.spec.ts
@@ -61,7 +61,6 @@ describe('RtcToNet', function() {
     mockPeerconnection = <any>{
       dataChannels: {},
       negotiateConnection: jasmine.createSpy('negotiateConnection'),
-      onceConnecting: noopPromise,
       onceConnected: noopPromise,
       onceClosed: noopPromise,
       peerOpenedChannelQueue: new handler.Queue(),

--- a/src/samples/copypaste-churn-chat-chromeapp/freedom-module.ts
+++ b/src/samples/copypaste-churn-chat-chromeapp/freedom-module.ts
@@ -36,9 +36,6 @@ freedomParentModule.on('handleSignalMessage', (message:ChurnSignallingMessage) =
   pc.handleSignalMessage(message);
 });
 
-pc.onceConnecting.then(() => { log.info('connecting...'); });
-
-
 export var connectDataChannel = (channel:peerconnection.DataChannel) => {
 	// Send messages over the datachannel, in response to events from the UI,
 	// and forward messages received on the datachannel to the UI.

--- a/src/samples/simple-churn-chat-chromeapp/freedom-module.ts
+++ b/src/samples/simple-churn-chat-chromeapp/freedom-module.ts
@@ -55,7 +55,6 @@ function makePeerConnection(name:string) {
   var pc :PeerConnection<churn_types.ChurnSignallingMessage> =
       new churn.Connection(freedom['core.rtcpeerconnection'](pcConfig),
       'churn-' + name);
-  pc.onceConnecting.then(() => { log.info(name + ': connecting...'); });
   pc.onceConnected.then(() => {
     log.info(name + ' connected');
   }, (e:Error) => {

--- a/src/samples/simple-freedom-chat/freedom-module.ts
+++ b/src/samples/simple-freedom-chat/freedom-module.ts
@@ -54,7 +54,6 @@ function makePeerConnection(name:string) {
   };
   var pc :PeerConnection<signals.Message> =
     peerconnection.createPeerConnection(pcConfig, name);
-  pc.onceConnecting.then(() => { log.info(name + ': connecting...'); });
   pc.onceConnected.then(() => {
     log.info(name + ' connected');
   }, (e:Error) => {

--- a/src/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/socks-to-rtc/socks-to-rtc.spec.ts
@@ -76,7 +76,6 @@ describe('SOCKS server', function() {
       peerOpenedChannelQueue: new handler.Queue<signals.Message, void>(),
       signalForPeerQueue: new handler.Queue<signals.Message, void>(),
       negotiateConnection: jasmine.createSpy('negotiateConnection'),
-      onceConnecting: noopPromise,
       onceConnected: noopPromise,
       onceClosed: noopPromise,
       close: jasmine.createSpy('close')


### PR DESCRIPTION
More public field removal: `onceConnecting` isn't used anywhere.

Also, remove references to `pcState` in various comments.

Tested with copypaste and uProxy.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/189)

<!-- Reviewable:end -->
