### PR TITLE
Setting DataChannel CHUNK_SIZE to 16K so it will match the Freedom so…

### DIFF
--- a/src/webrtc/datachannel.ts
+++ b/src/webrtc/datachannel.ts
@@ -14,8 +14,8 @@ import arraybuffers = require('../arraybuffers/arraybuffers');
 import logging = require('../logging/logging');
 var log :logging.Log = new logging.Log('DataChannel');
 
-// Messages are limited to a 16KB length by SCTP; we use 15k for safety.
-// TODO: test if we can up this to 16k; test the edge-cases!
+// Messages are limited to a 16KB length by SCTP. For maximum efficiency,
+// this size should match the buffer size used by Freedom's TCP connection.
 // http://tools.ietf.org/html/draft-ietf-rtcweb-data-channel-07#section-6.6
 export var CHUNK_SIZE = 1024 * 16;
 

--- a/src/webrtc/datachannel.ts
+++ b/src/webrtc/datachannel.ts
@@ -17,7 +17,7 @@ var log :logging.Log = new logging.Log('DataChannel');
 // Messages are limited to a 16KB length by SCTP; we use 15k for safety.
 // TODO: test if we can up this to 16k; test the edge-cases!
 // http://tools.ietf.org/html/draft-ietf-rtcweb-data-channel-07#section-6.6
-export var CHUNK_SIZE = 1024 * 15;
+export var CHUNK_SIZE = 1024 * 16;
 
 // The maximum amount of bytes we should allow to get queued up in
 // peerconnection. Any more and we start queueing in JS. There are two reasons


### PR DESCRIPTION
The Freedom TCP Chrome socket size change got us 15% in speed. By matching the buffer sizes we get another  60% for about 85% overall.

This is related to https://github.com/uProxy/uproxy/issues/1563.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/191)

<!-- Reviewable:end -->
