### PR TITLE
updating pgp api freedom-pgp-e2e v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "freedom": "^0.6.25",
     "freedom-for-chrome": "^0.4.19",
     "freedom-for-firefox": "^0.6.14",
-    "freedom-pgp-e2e": "^0.3.1",
+    "freedom-pgp-e2e": "^0.4.0",
     "grunt": "^0.4.5",
     "grunt-browserify": "^3.0.1",
     "grunt-contrib-clean": "^0.6.0",

--- a/src/samples/copypaste-socks-chromeapp/freedom-module.ts
+++ b/src/samples/copypaste-socks-chromeapp/freedom-module.ts
@@ -32,8 +32,8 @@ pgp.setup('', 'uProxy user <noreply@uproxy.org>');
 
 var parentModule = freedom();
 
-pgp.exportKey().then((publicKey:string) => {
-  parentModule.emit('publicKeyExport', publicKey);
+pgp.exportKey().then((publicKey:PublicKey) => {
+  parentModule.emit('publicKeyExport', publicKey.key);
 });
 
 var pcConfig :freedom_RTCPeerConnection.RTCConfiguration = {

--- a/third_party/freedom-typings/pgp.d.ts
+++ b/third_party/freedom-typings/pgp.d.ts
@@ -3,18 +3,14 @@
 // This is the interface that a module that has logger as a dependency gets to
 // use.
 
-interface PgpKey {
-  uids :string[];
+interface PublicKey {
+  key :string;
+  fingerprint :string;
 }
 
 interface VerifyDecryptResult {
   data :ArrayBuffer;
   signedBy :string[];
-}
-
-interface PublicKey {
-  key :string;
-  fingerprint :string;
 }
 
 interface PgpProvider {

--- a/third_party/freedom-typings/pgp.d.ts
+++ b/third_party/freedom-typings/pgp.d.ts
@@ -12,10 +12,15 @@ interface VerifyDecryptResult {
   signedBy :string[];
 }
 
+interface PublicKey {
+  key :string;
+  fingerprint :string;
+}
+
 interface PgpProvider {
   // Standard freedom crypto API
   setup(passphrase:string, userid:string) :Promise<void>;
-  exportKey() :Promise<string>;
+  exportKey() :Promise<PublicKey>;
   signEncrypt(data:ArrayBuffer, encryptKey?:string,
               sign?:boolean) :Promise<ArrayBuffer>;
   verifyDecrypt(data:ArrayBuffer,


### PR DESCRIPTION
This is the tweak to the API needed to accommodate the change from: https://github.com/freedomjs/freedom-pgp-e2e/pull/34

And more generally, this sample should hopefully help illustrate how to use freedom-pgp-e2e in uProxy.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/195)

<!-- Reviewable:end -->
