### PR TITLE
no need to send churn candidates to the remote peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "27.2.3",
+  "version": "27.2.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"

--- a/src/churn/churn.ts
+++ b/src/churn/churn.ts
@@ -294,20 +294,21 @@ var log :logging.Log = new logging.Log('churn');
       // Debugging.
       this.onceProbingComplete_.then((endpoint:NatPair) => {
         log.debug('%1: NAT endpoints of probe connection are %2',
-            this.peerName,
-            JSON.stringify(endpoint));
+          this.peerName, endpoint);
       });
       this.onceHaveWebRtcEndpoint_.then((endpoint:net.Endpoint) => {
         log.debug('%1: obfuscated connection is bound to %2',
-            this.peerName,
-            JSON.stringify(endpoint));
+          this.peerName, endpoint);
       });
       this.onceHaveRemoteEndpoint_.then((endpoint:net.Endpoint) => {
         log.debug('%1: remote peer is contactable at %2',
-            this.peerName,
-            JSON.stringify(endpoint));
+          this.peerName, endpoint);
       });
-      this.onceHaveCaesarKey_.then((key:number) => {
+      this.onceHaveForwardingSocketEndpoint_.then((endpoint: net.Endpoint) => {
+        log.debug('%1: forwarding socket is at %2',
+          this.peerName, endpoint);
+      });
+      this.onceHaveCaesarKey_.then((key: number) => {
         log.debug('%1: caesar key is %2', this.peerName, key);
       });
     }


### PR DESCRIPTION
I made this change when debugging the recent localhost-related issue, thinking it might be why Firefox was having trouble parsing candidates. It's not, but I kinda like how it eliminates the need to send a bunch of (useless) candidates to the remote peer.

Thoughts?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/197)

<!-- Reviewable:end -->
