### PR TITLE
eliminate errors on churn startup, with some other logging cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "27.2.4",
+  "version": "27.2.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"

--- a/src/bridge/bridge.ts
+++ b/src/bridge/bridge.ts
@@ -158,7 +158,7 @@ export class BridgingPeerConnection implements peerconnection.PeerConnection<
   }
 
   public negotiateConnection = () : Promise<void> => {
-    log.debug('%1: negotiating, offering %2 provider',
+    log.info('%1: negotiating, offering %2 provider',
         this.name_, ProviderType[this.preferredProviderType_]);
     this.bridgeWith_(
         this.preferredProviderType_,

--- a/src/churn/churn.ts
+++ b/src/churn/churn.ts
@@ -301,7 +301,7 @@ var log :logging.Log = new logging.Log('churn');
           this.peerName, endpoint);
       });
       this.onceHaveRemoteEndpoint_.then((endpoint:net.Endpoint) => {
-        log.info('%1: remote peer is contactable at %2',
+        log.debug('%1: remote peer is contactable at %2',
           this.peerName, endpoint);
       });
       this.onceHaveForwardingSocketEndpoint_.then((endpoint: net.Endpoint) => {
@@ -358,7 +358,11 @@ var log :logging.Log = new logging.Log('churn');
       Promise.all<any>([
           this.pipe_.bindLocal(natEndpoints.internal),
           this.pipe_.setBrowserEndpoint(webRtcEndpoint),
-          bindRemote]).then((answers:any[]) => {
+          bindRemote]).then(
+          (answers:any[]) => {
+        log.info('%1: pipe bound to %2, forwarding packets to ' +
+            'remote peer at %3', this.peerName, natEndpoints.internal,
+            remoteEndpoint);
         log.info('%1: created initial mirror socket at %2',
             this.peerName, answers[2]);
       });

--- a/src/churn/churn.ts
+++ b/src/churn/churn.ts
@@ -297,11 +297,11 @@ var log :logging.Log = new logging.Log('churn');
           this.peerName, endpoint);
       });
       this.onceHaveWebRtcEndpoint_.then((endpoint:net.Endpoint) => {
-        log.debug('%1: obfuscated connection is bound to %2',
+        log.info('%1: obfuscated connection is bound to %2',
           this.peerName, endpoint);
       });
       this.onceHaveRemoteEndpoint_.then((endpoint:net.Endpoint) => {
-        log.debug('%1: remote peer is contactable at %2',
+        log.info('%1: remote peer is contactable at %2',
           this.peerName, endpoint);
       });
       this.onceHaveForwardingSocketEndpoint_.then((endpoint: net.Endpoint) => {
@@ -359,8 +359,8 @@ var log :logging.Log = new logging.Log('churn');
           this.pipe_.bindLocal(natEndpoints.internal),
           this.pipe_.setBrowserEndpoint(webRtcEndpoint),
           bindRemote]).then((answers:any[]) => {
-        log.info('%1: initial mirror socket for remote peer at %2 on %3',
-            this.peerName, remoteEndpoint, answers[2]);
+        log.info('%1: created initial mirror socket at %2',
+            this.peerName, answers[2]);
       });
     }
 

--- a/src/webrtc/datachannel.ts
+++ b/src/webrtc/datachannel.ts
@@ -185,6 +185,8 @@ export class DataChannelClass implements DataChannel {
     this.onceOpened.then(() => {
       this.isOpen_ = true;
       this.sendNext_();
+    }, (e:Error) => {
+      log.debug('failed to open');
     });
     this.onceClosed.then(() => {
         if(!this.isOpen_) {

--- a/src/webrtc/peerconnection.ts
+++ b/src/webrtc/peerconnection.ts
@@ -472,12 +472,15 @@ export class PeerConnectionClass implements PeerConnection<signals.Message> {
 
   // Saves the given data channel as the control channel for this peer
   // connection. The appropriate callbacks for opening, closing, and
-  // initiating a heartbeat is are registered here.
+  // initiating a heartbeat are registered here.
   private registerControlChannel_ = (channel:DataChannel) : void => {
-    channel.onceOpened.then().then(() => {
+    channel.onceOpened.then(() => {
       this.initiateHeartbeat_(channel);
       this.state_ = State.CONNECTED;
       this.fulfillConnected_();
+    }).catch((e: Error) => {
+      log.debug('%1: control channel failed to open: %2',
+          this.peerName_, e.message);
     });
     channel.onceClosed.then(this.close);
   }

--- a/src/webrtc/peerconnection.ts
+++ b/src/webrtc/peerconnection.ts
@@ -265,6 +265,8 @@ export class PeerConnectionClass implements PeerConnection<signals.Message> {
       this.state_ = State.CONNECTING;
       this.pc_.createOffer().then(
           (d:freedom_RTCPeerConnection.RTCSessionDescription) => {
+        log.debug('%1: created offer: %2', this.peerName_, d);
+
         // Emit the offer signal before calling setLocalDescription, which
         // initiates ICE candidate gathering. If we did the reverse then
         // we may emit ICE candidate signals before the offer, confusing
@@ -334,6 +336,8 @@ export class PeerConnectionClass implements PeerConnection<signals.Message> {
       return this.pc_.setRemoteDescription(description)
     }).then(this.pc_.createAnswer).then(
         (d:freedom_RTCPeerConnection.RTCSessionDescription) => {
+      log.debug('%1: created answer: %2', this.peerName_, d);
+
       // As with the offer, we must emit the signal before
       // setting the local description to ensure that we send the
       // ANSWER before any ICE candidates.
@@ -373,7 +377,6 @@ export class PeerConnectionClass implements PeerConnection<signals.Message> {
 
   // Adds a signalling message to this.signalForPeerQueue.
   private emitSignalForPeer_ = (message:signals.Message) : void => {
-    log.debug('%1: signal for peer: %2', this.peerName_, message);
     this.signalForPeerQueue.handle(message);
   }
 
@@ -381,7 +384,7 @@ export class PeerConnectionClass implements PeerConnection<signals.Message> {
   // Return type is for testing.
   // TODO: consider adding return type to PeerConnection interface
   public handleSignalMessage = (message:signals.Message) : Promise<void> => {
-    log.debug('%1: handling signal from peer: %2', this.peerName_, message);
+    log.info('%1: handling signal from peer: %2', this.peerName_, message);
 
     // If we are offering and they are also offering at the same time, pick
     // the one who has the lower hash value for their description: this is


### PR DESCRIPTION
Mostly, this eliminates the nasty uncaught exception for every churn connection.

Also, a few other bits and bobs I would have appreciated recently when debugging churn. We have been logging mostly at DEBUG but INFO also has a place.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/198)

<!-- Reviewable:end -->
