### PR TITLE
readonly is necessary for copy on firefox

### DIFF
--- a/src/copypaste-socks/polymer-components/giver.html
+++ b/src/copypaste-socks/polymer-components/giver.html
@@ -27,7 +27,7 @@
 
       <br>
       <div id='step2ContainerNode' style='display: {{ model.readyForStep2 ? "block" : "none" }};'>
-        <textarea id='outboundMessageNode' disabled value='{{ model.outboundMessageValue }}'></textarea>
+        <textarea id='outboundMessageNode' readonly value='{{ model.outboundMessageValue }}'></textarea>
         <p><bdi i18n-content='copyPasteAndSend'></bdi></p>
         <p class='warning'><bdi i18n-content='warning'></bdi></p>
       </div>


### PR DESCRIPTION
Oops, this allows Firefox be a giver, not a getter.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/205)

<!-- Reviewable:end -->
