### PR TITLE
remove (SocksToRtc|RtcToNet).startFromConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "27.5.0",
+  "version": "28.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"

--- a/src/copypaste-socks/freedom-module.ts
+++ b/src/copypaste-socks/freedom-module.ts
@@ -178,9 +178,9 @@ parentModule.on('handleSignalMessage', (message:signals.Message) => {
   } else {
     if (rtcNet === undefined) {
       rtcNet = new rtc_to_net.RtcToNet();
-      rtcNet.startFromConfig({
-        allowNonUnicast:true
-      }, pcConfig);
+      rtcNet.start({
+        allowNonUnicast: true
+      }, bridge.best('rtctonet', pcConfig));
       log.info('created rtc-to-net');
 
       // Forward signalling channel messages to the UI.

--- a/src/integration-tests/socks-echo/proxy-integration-test.ts
+++ b/src/integration-tests/socks-echo/proxy-integration-test.ts
@@ -1,19 +1,18 @@
 /// <reference path='../../../../third_party/freedom-typings/freedom-common.d.ts' />
 
+import arraybuffers = require('../../arraybuffers/arraybuffers');
+import bridge = require('../../bridge/bridge');
+import net = require('../../net/net.types');
 import peerconnection = require('../../webrtc/peerconnection');
+import proxyintegrationtesttypes = require('./proxy-integration-test.types');
+import rtc_to_net = require('../../rtc-to-net/rtc-to-net');
+import socks = require('../../socks-common/socks-headers');
+import socks_to_rtc = require('../../socks-to-rtc/socks-to-rtc');
+import tcp = require('../../net/tcp');
 
 import ProxyConfig = require('../../rtc-to-net/proxyconfig');
-import rtc_to_net = require('../../rtc-to-net/rtc-to-net');
-import socks_to_rtc = require('../../socks-to-rtc/socks-to-rtc');
-import net = require('../../net/net.types');
-import tcp = require('../../net/tcp');
-import socks = require('../../socks-common/socks-headers');
-
-import proxyintegrationtesttypes = require('./proxy-integration-test.types');
 import ProxyIntegrationTester = proxyintegrationtesttypes.ProxyIntegrationTester;
 import ReceivedDataEvent = proxyintegrationtesttypes.ReceivedDataEvent;
-
-import arraybuffers = require('../../arraybuffers/arraybuffers');
 
 // This abstract class is converted into a real class by Freedom, which
 // fills in the unimplemented on(...) method in the process of
@@ -84,7 +83,8 @@ class AbstractProxyIntegrationTest implements ProxyIntegrationTester {
     this.rtcToNet_.startFromConfig(rtcToNetProxyConfig, rtcPcConfig);
     this.rtcToNet_.signalsForPeer.setSyncHandler(this.socksToRtc_.handleSignalFromPeer);
     this.socksToRtc_.on('signalForPeer', this.rtcToNet_.handleSignalFromPeer);
-    return this.socksToRtc_.startFromConfig(socksToRtcEndpoint, rtcPcConfig, obfuscate);
+    return this.socksToRtc_.start(new tcp.Server(socksToRtcEndpoint),
+        bridge.best('sockstortc', rtcPcConfig));
   }
 
   // Assumes webEndpoint is IPv4.

--- a/src/integration-tests/socks-echo/proxy-integration-test.ts
+++ b/src/integration-tests/socks-echo/proxy-integration-test.ts
@@ -80,7 +80,8 @@ class AbstractProxyIntegrationTest implements ProxyIntegrationTester {
 
     this.socksToRtc_ = new socks_to_rtc.SocksToRtc();
     this.rtcToNet_ = new rtc_to_net.RtcToNet('the user id');
-    this.rtcToNet_.startFromConfig(rtcToNetProxyConfig, rtcPcConfig);
+    this.rtcToNet_.start(rtcToNetProxyConfig,
+        bridge.best('sockstortc', rtcPcConfig));
     this.rtcToNet_.signalsForPeer.setSyncHandler(this.socksToRtc_.handleSignalFromPeer);
     this.socksToRtc_.on('signalForPeer', this.rtcToNet_.handleSignalFromPeer);
     return this.socksToRtc_.start(new tcp.Server(socksToRtcEndpoint),

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -5,22 +5,18 @@
 /// <reference path='../../../third_party/freedom-typings/freedom-module-env.d.ts' />
 /// <reference path='../../../third_party/ipaddrjs/ipaddrjs.d.ts' />
 
-import freedom_types = require('freedom.types');
-import ipaddr = require('ipaddr.js');
-
 import arraybuffers = require('../arraybuffers/arraybuffers');
-import peerconnection = require('../webrtc/peerconnection');
+import freedom_types = require('freedom.types');
 import handler = require('../handler/queue');
-
-import ProxyConfig = require('./proxyconfig');
-
-import bridge = require('../bridge/bridge');
-import net = require('../net/net.types');
-import tcp = require('../net/tcp');
-import socks = require('../socks-common/socks-headers');
-import Pool = require('../pool/pool');
-
+import ipaddr = require('ipaddr.js');
 import logging = require('../logging/logging');
+import net = require('../net/net.types');
+import peerconnection = require('../webrtc/peerconnection');
+import socks = require('../socks-common/socks-headers');
+import tcp = require('../net/tcp');
+
+import Pool = require('../pool/pool');
+import ProxyConfig = require('./proxyconfig');
 
 // module RtcToNet {
 
@@ -156,13 +152,6 @@ import logging = require('../logging/logging');
 
     // |userId_| is used to enforce user-wide resource limits.
     public constructor(private userId_?:string) {}
-
-    // As start() but handles creation of a bridging peerconnection.
-    public startFromConfig = (
-        proxyConfig:ProxyConfig,
-        config:freedom_RTCPeerConnection.RTCConfiguration) => {
-      return this.start(proxyConfig, bridge.best('rtctonet', config));
-    }
 
     // Starts with the supplied peerconnection.
     // Returns this.onceReady.

--- a/src/simple-socks/freedom-module.ts
+++ b/src/simple-socks/freedom-module.ts
@@ -34,7 +34,9 @@ var pcConfig :freedom_RTCPeerConnection.RTCConfiguration = {
 };
 
 export var rtcNet = new rtc_to_net.RtcToNet();
-rtcNet.startFromConfig({ allowNonUnicast: true }, pcConfig);
+rtcNet.start({
+  allowNonUnicast: true
+}, bridge.best('sockstortc', pcConfig));
 
 //-----------------------------------------------------------------------------
 export var socksRtc = new socks_to_rtc.SocksToRtc();

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -3,16 +3,13 @@
 /// <reference path='../../../third_party/freedom-typings/freedom-module-env.d.ts' />
 
 import arraybuffers = require('../arraybuffers/arraybuffers');
-import peerconnection = require('../webrtc/peerconnection');
 import handler = require('../handler/queue');
-
-import bridge = require('../bridge/bridge');
 import net = require('../net/net.types');
-import tcp = require('../net/tcp');
-import socks = require('../socks-common/socks-headers');
-import Pool = require('../pool/pool');
-
 import logging = require('../logging/logging');
+import peerconnection = require('../webrtc/peerconnection');
+import Pool = require('../pool/pool');
+import socks = require('../socks-common/socks-headers');
+import tcp = require('../net/tcp');
 
 // SocksToRtc passes socks requests over WebRTC datachannels.
 module SocksToRtc {
@@ -91,30 +88,8 @@ module SocksToRtc {
       }
     }
 
-    // Handles creation of a TCP server and bridging peerconnection. Returns
-    // the endpoint it ended up listening on (if |localSocksServerEndpoint|
-    // has port set to 0 then a dynamic port is allocated and this port is
-    // returned within the promise's endpoint).
-    // NOTE: Users of this class MUST add on-event listeners before calling
-    //       this method.
-    // NOTE: The arguments here are likely to change as more PeerConnection
-    //       providers and options are added; for now, setting obfuscate to
-    //       true implies the basicObfuscation bridge while false implies
-    //       preObfuscation.
-    public startFromConfig = (
-        localSocksServerEndpoint:net.Endpoint,
-        config:freedom_RTCPeerConnection.RTCConfiguration,
-        obfuscate?:boolean) : Promise<net.Endpoint> => {
-      return this.start(
-          new tcp.Server(localSocksServerEndpoint),
-          obfuscate ?
-            bridge.basicObfuscation('sockstortc', config) :
-            bridge.preObfuscation('sockstortc', config));
-    }
-
     // Starts the SOCKS server with the supplied TCP server and peerconnection.
-    // Returns a promise that resolves when the server is ready to use. This
-    // method is public only for testing purposes.
+    // Returns a promise that resolves when the server is ready to use.
     public start = (
         tcpServer:tcp.Server,
         peerconnection:peerconnection.PeerConnection<Object>)


### PR DESCRIPTION
In the interest of having smaller interfaces, and how the args for `SocksToRtc` are threatening to spiral out of control as we add more and more options...remove this.

uProxy doesn't use these functions so it's just fine.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/211)

<!-- Reviewable:end -->
