### PR TITLE
Only bind to the ANY interface, because this is all Firefox supports anyway

### DIFF
--- a/src/churn-pipe/churn-pipe.ts
+++ b/src/churn-pipe/churn-pipe.ts
@@ -296,6 +296,8 @@ class Pipe {
     return Promise.all(promises).then((fulfills:any[]) : void => {});
   }
 
+  // Returns the "any" interface with the same address family (IPv4 or IPv6) as
+  // |address|.
   private static anyInterface_ = (address:string) => {
     return ipaddr.IPv6.isValid(address) ? '::' : '0.0.0.0';
   }


### PR DESCRIPTION
This unblocks https://github.com/freedomjs/freedom-for-firefox/pull/68, which would otherwise break this code.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/212)

<!-- Reviewable:end -->
