### PR TITLE
add a ping command to the copypaste control port

### DIFF
--- a/src/copypaste-socks/main.core-env.ts
+++ b/src/copypaste-socks/main.core-env.ts
@@ -44,7 +44,7 @@ module copypaste_module {
       console.log('gatherMessage invoked.');
       console.log('gatherMessage: sending back:' + model.outboundMessageValue);
 
-      copypaste.emit('getSendBack', model.outboundMessageValue);
+      copypaste.emit('controlPortCallback', model.outboundMessageValue);
     });
 
     copypaste.on('giveWithSDP', (sdp:string) => {
@@ -52,7 +52,7 @@ module copypaste_module {
       consumeInboundMessage();
       setTimeout(() => {
         console.log("Emitting giveSendback with SDP: " + model.outboundMessageValue);
-        copypaste.emit('giveSendBack', model.outboundMessageValue);
+        copypaste.emit('controlPortCallback', model.outboundMessageValue);
       }, 500);
     });
 


### PR DESCRIPTION
Because of Docker port forwarding, `netstat` won't suffice to tell if the port is alive. This adds a ping command, which we can poll with `nc`:
https://github.com/uProxy/uproxy-docker/compare/trevj-start-wait?expand=1

Also a little refactoring.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/214)

<!-- Reviewable:end -->
