### PR TITLE
add bower dependency, so that it does not have to be installed globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "arraybuffer-slice": "^0.1.2",
     "babar": "^0.0.3",
+    "bower": "^1.4.1",
     "browserify-istanbul": "^0.2.0",
     "circular-json": "^0.1.6",
     "crypto": "^0.0.3",

--- a/setup.sh
+++ b/setup.sh
@@ -4,6 +4,7 @@
 # allows script to be run from different directories but always act on the
 # directory it is within.
 ROOT_DIR="$(cd "$(dirname $0)"; pwd)";
+NPM_BIN_DIR="$ROOT_DIR/node_modules/.bin"
 
 # A simple bash script to run commands to setup and install all dev dependencies
 # (including non-npm ones)
@@ -13,7 +14,7 @@ function runAndAssertCmd ()
     echo
     # We use set -e to make sure this will fail if the command returns an error
     # code.
-    set -e && eval $1
+    set -e && cd $ROOT_DIR && eval $1
 }
 
 # Just run the command, ignore errors (e.g. cp fails if a file already exists
@@ -22,25 +23,23 @@ function runCmd ()
 {
     echo "Running: $1"
     echo
-    eval $1
+    cd $ROOT_DIR && eval $1
 }
 
 function buildTools ()
 {
-  runCmd "cd $ROOT_DIR"
   runCmd "mkdir -p build/dev/uproxy-lib/build-tools/"
-  runCmd "cp $ROOT_DIR/src/build-tools/*.ts build/dev/uproxy-lib/build-tools/"
-  runAndAssertCmd "./node_modules/.bin/tsc --module commonjs --noImplicitAny ./build/dev/uproxy-lib/build-tools/*.ts"
+  runCmd "cp src/build-tools/*.ts build/dev/uproxy-lib/build-tools/"
+  runAndAssertCmd "$NPM_BIN_DIR/tsc --module commonjs --noImplicitAny ./build/dev/uproxy-lib/build-tools/*.ts"
   runCmd "mkdir -p ./build/tools/"
-  runCmd "cp ./build/dev/uproxy-lib/build-tools/*.js ./build/tools/"
+  runCmd "cp build/dev/uproxy-lib/build-tools/*.js build/tools/"
 }
 
 function thirdParty ()
 {
-  runCmd "cd $ROOT_DIR"
-  runAndAssertCmd "bower install --allow-root --config.interactive=false"
+  runAndAssertCmd "$NPM_BIN_DIR/bower install --allow-root --config.interactive=false"
   runAndAssertCmd "mkdir -p build/third_party"
-  runAndAssertCmd "node_modules/.bin/tsd reinstall --config ./third_party/tsd.json"
+  runAndAssertCmd "$NPM_BIN_DIR/tsd reinstall --config ./third_party/tsd.json"
   runAndAssertCmd "cp -r third_party/* build/third_party/"
   runAndAssertCmd "mkdir -p build/third_party/freedom-pgp-e2e"
   runAndAssertCmd "cp -r node_modules/freedom-pgp-e2e/dist build/third_party/freedom-pgp-e2e/"
@@ -53,7 +52,6 @@ function clean ()
 
 function installDevDependencies ()
 {
-  runCmd "cd $ROOT_DIR"
   runAndAssertCmd "npm install"
   thirdParty
   buildTools


### PR DESCRIPTION
Oopsy, turns out we actually still do need bower installed globally.

I stole this fix from uProxy:
https://github.com/uProxy/uproxy/blob/dev/setup.sh#L7

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/223)
<!-- Reviewable:end -->
