### PR TITLE
workaround to definitively prevent suspend

### DIFF
--- a/src/samples/adventure-chromeapp/background.js
+++ b/src/samples/adventure-chromeapp/background.js
@@ -1,13 +1,27 @@
-var script = document.createElement('script');
-script.src = 'freedom-for-chrome/freedom-for-chrome.js';
-document.head.appendChild(script);
-script.onload = function() {
-  freedom('uproxy-lib/adventure/freedom-module.json', {
-    'logger': 'uproxy-lib/loggingprovider/freedom-module.json',
-    'debug': 'debug'
-  }).then(function(moduleFactory) {
-    moduleFactory();
-  }, function() {
-    console.error('could not load freedomjs module');
+chrome.app.runtime.onLaunched.addListener(function() {
+  // Prevent the app from suspending.
+  // TODO: Use persistent sockets instead:
+  //       https://github.com/uProxy/uproxy/issues/1746
+  chrome.app.window.create('index.html', {
+  	id: "adventure",
+    outerBounds: {
+      width: 200,
+      height: 200,
+    }
   });
-}
+
+  var script = document.createElement('script');
+  script.src = 'freedom-for-chrome/freedom-for-chrome.js';
+  document.head.appendChild(script);
+  script.onload = function() {
+    console.log('loading freedom!');
+    freedom('uproxy-lib/adventure/freedom-module.json', {
+      'logger': 'uproxy-lib/loggingprovider/freedom-module.json',
+      'debug': 'debug'
+    }).then(function(moduleFactory) {
+      moduleFactory();
+    }, function() {
+      console.error('could not load freedomjs module');
+    });
+  };
+});

--- a/src/samples/adventure-chromeapp/index.html
+++ b/src/samples/adventure-chromeapp/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>adventure</title>
+  </head>
+  <body>
+    <h1>adventure</h1>
+  </body>
+</html>


### PR DESCRIPTION
I'm still seeing suspend occasionally...this adds an explicit handler for `onLaunched` and opens a window. Filed an issue to properly handle suspend at some point in the future:
https://github.com/uProxy/uproxy/issues/1746

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/227)

<!-- Reviewable:end -->
