### PR TITLE
Version number 28.0.0 => 29.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "28.0.0",
+  "version": "29.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"


### PR DESCRIPTION
Bumped the version number – uproxy-lib now includes the freedom-port-control module.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/228)

<!-- Reviewable:end -->
