### PR TITLE
Use actual local interfaces in the mirror candidates.

### DIFF
--- a/src/churn-pipe/churn-pipe.ts
+++ b/src/churn-pipe/churn-pipe.ts
@@ -310,11 +310,11 @@ class Pipe {
     log.debug('%1: binding %2 mirror(s) for remote endpoint: %3',
         this.name_, this.maxSocketsPerInterface_, remoteEndpoint);
     this.ensureRemoteEndpoint_(remoteEndpoint, true);
-    var promises :any[] = [];
+    var promises :Promise<void>[] = [];
     for (var i = 0; i < this.maxSocketsPerInterface_; ++i) {
       promises.push(this.getMirrorSocketAndEmit_(remoteEndpoint, i));
     }
-    return Promise.all(promises).then((fulfills:any[]) : void => {});
+    return Promise.all(promises).then((fulfills:void[]) : void => {});
   }
 
   // Returns the "any" interface with the same address family (IPv4 or IPv6) as
@@ -378,9 +378,12 @@ class Pipe {
   }
 
   private getLocalInterface_ = (anyAddress:string) : string => {
+    // This method will not work until bindLocal populates |lastInterface_|.
     var isIPv6 = ipaddr.IPv6.isValid(anyAddress);
     var address = isIPv6 ? this.lastInterface_.v6 : this.lastInterface_.v4;
     if (!address) {
+      // This error would only occur if this method were called (from
+      // bindRemote) before bindLocal was called.
       throw new Error('No known interface to match ' + anyAddress);
     }
     return address;

--- a/src/churn/churn.ts
+++ b/src/churn/churn.ts
@@ -170,9 +170,9 @@ export var filterCandidatesFromSdp = (sdp:string) : string => {
     });
 
     private pipe_ :ChurnPipe;
+    private havePipe_ :() => void;
     // |onceHavePipe_| resolves once the churn pipe has been created and the
     // probe candidates have been added to the pipe.
-    private havePipe_ :() => void;
     private onceHavePipe_ = new Promise((F,R) => {
       this.havePipe_ = F;
     });
@@ -192,9 +192,9 @@ export var filterCandidatesFromSdp = (sdp:string) : string => {
       this.portControl_ = freedom['portControl']();
 
       this.configureObfuscatedConnection_();
-      this.configureProbeConnection_(probeRtcPc);
       // When the probe connection is complete, it will trigger the
       // creation of the churn pipe.
+      this.configureProbeConnection_(probeRtcPc);
 
       // Forward onceXxx promises.
       this.onceConnected = this.obfuscatedConnection_.onceConnected;


### PR DESCRIPTION
Windows does not allow physical interfaces to send to loopback.
Fixes https://github.com/uProxy/uproxy/issues/1740

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/231)

<!-- Reviewable:end -->
