### PR TITLE
Tolerate duplicate negotiationneeded events in Firefox 40

### DIFF
--- a/src/webrtc/peerconnection.ts
+++ b/src/webrtc/peerconnection.ts
@@ -284,7 +284,11 @@ export class PeerConnectionClass implements PeerConnection<signals.Message> {
         this.closeWithError_('failed to set local description: ' + e.message);
       });
     } else {
-      this.closeWithError_('onnegotiationneeded fired in unexpected state ' +
+      // This should never happen, but in Firefox 40+, we get a redundant
+      // event because both the browser and the polyfill generate one.
+      // TODO: Remove the polyfill, and make this warning an error, once
+      // Firefox <40 is no longer supported.
+      log.warn('onnegotiationneeded fired in unexpected state ' +
           State[this.state_]);
     }
   }


### PR DESCRIPTION
This is half of a fix to https://github.com/uProxy/uproxy/issues/1777 .  (The other half is change to freedom-for-firefox.)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/241)

<!-- Reviewable:end -->
