### PR TITLE
migrate to freedom-for-firefox with fix for UDP sockets, and bump version number for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "29.0.4",
+  "version": "29.0.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"
@@ -33,7 +33,7 @@
     "es6-promise": "^2.0.0",
     "freedom": "^0.6.25",
     "freedom-for-chrome": "^0.4.19",
-    "freedom-for-firefox": "^0.6.17",
+    "freedom-for-firefox": "^0.6.18",
     "freedom-pgp-e2e": "^0.5.2",
     "grunt": "^0.4.5",
     "grunt-browserify": "^3.0.1",


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/242)
<!-- Reviewable:end -->
