### PR TITLE
UPnP failures will be logged now

### DIFF
--- a/src/churn/churn.ts
+++ b/src/churn/churn.ts
@@ -231,8 +231,8 @@ export var filterCandidatesFromSdp = (sdp:string) : string => {
               this.portControl_.addMapping(c.relatedPort, c.port, MAP_LIFETIME).
                   then((mapping:freedom_PortControl.Mapping) => {
                     if (mapping.externalPort === -1) {
-                      log.debug("addMapping() failed.");
-                      log.debug("Failed UPnP mapping object: ", mapping);
+                      log.debug("addMapping() failed. UPnP mapping object: ", 
+                                mapping);
                     } else {
                       log.debug("addMapping() success: ", mapping);
                     }

--- a/src/churn/churn.ts
+++ b/src/churn/churn.ts
@@ -232,6 +232,7 @@ export var filterCandidatesFromSdp = (sdp:string) : string => {
                   then((mapping:freedom_PortControl.Mapping) => {
                     if (mapping.externalPort === -1) {
                       log.debug("addMapping() failed.");
+                      log.debug("Failed UPnP mapping object: ", mapping);
                     } else {
                       log.debug("addMapping() success: ", mapping);
                     }

--- a/src/churn/churn.ts
+++ b/src/churn/churn.ts
@@ -231,7 +231,7 @@ export var filterCandidatesFromSdp = (sdp:string) : string => {
               this.portControl_.addMapping(c.relatedPort, c.port, MAP_LIFETIME).
                   then((mapping:freedom_PortControl.Mapping) => {
                     if (mapping.externalPort === -1) {
-                      log.debug("addMapping() failed. UPnP mapping object: ", 
+                      log.debug("addMapping() failed. Mapping object: ", 
                                 mapping);
                     } else {
                       log.debug("addMapping() success: ", mapping);

--- a/third_party/freedom-typings/port-control.d.ts
+++ b/third_party/freedom-typings/port-control.d.ts
@@ -11,6 +11,7 @@ declare module freedom_PortControl {
         protocol :string;
         timeoutId ?:number;
         nonce ?:number[];
+        errInfo ?:string;
     }
     // A collection of Mappings
     interface ActiveMappings {


### PR DESCRIPTION
We now `log.debug` a UPnP failure mapping object, so it's included in the submit feedback logs.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/244)

<!-- Reviewable:end -->
