### PR TITLE
Churn uses uproxy core's port control module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-lib",
   "description": "Shared libraries for uProxy projects.",
-  "version": "29.0.6",
+  "version": "29.0.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-lib"

--- a/src/copypaste-socks/freedom-module.ts
+++ b/src/copypaste-socks/freedom-module.ts
@@ -56,6 +56,8 @@ var pcConfig :freedom_RTCPeerConnection.RTCConfiguration = {
 var socksRtc:socks_to_rtc.SocksToRtc;
 var rtcNet:rtc_to_net.RtcToNet;
 
+var portControl = freedom['portControl']();
+
 var doStart = () => {
   var localhostEndpoint:net.Endpoint = { address: '0.0.0.0', port: 9999 };
 
@@ -82,7 +84,7 @@ var doStart = () => {
   });
 
   socksRtc.start(new tcp.Server(localhostEndpoint),
-      bridge.best('sockstortc', pcConfig)).then(
+      bridge.best('sockstortc', pcConfig, portControl)).then(
       (endpoint:net.Endpoint) => {
     log.info('SocksToRtc listening on %1', endpoint);
     log.info('curl -x socks5h://%1:%2 www.example.com',
@@ -106,7 +108,7 @@ parentModule.on('handleSignalMessage', (message:signals.Message) => {
       rtcNet = new rtc_to_net.RtcToNet();
       rtcNet.start({
         allowNonUnicast: true
-      }, bridge.best('rtctonet', pcConfig));
+      }, bridge.best('rtctonet', pcConfig, portControl));
       log.info('created rtc-to-net');
 
       // Forward signalling channel messages to the UI.

--- a/src/samples/copypaste-churn-chat-chromeapp/freedom-module.ts
+++ b/src/samples/copypaste-churn-chat-chromeapp/freedom-module.ts
@@ -20,8 +20,10 @@ var config :freedom_RTCPeerConnection.RTCConfiguration = {
                {urls: ['stun:stun1.l.google.com:19302']}]
 };
 
+var portControl = freedom['portControl']();
+
 export var freedomPc = freedom['core.rtcpeerconnection'](config);
-export var pc = new churn.Connection(freedomPc);
+export var pc = new churn.Connection(freedomPc, undefined, undefined, portControl);
 export var freedomParentModule = freedom();
 
 // Forward signalling channel messages to the UI.

--- a/third_party/freedom-typings/port-control.d.ts
+++ b/third_party/freedom-typings/port-control.d.ts
@@ -37,7 +37,8 @@ declare module freedom_PortControl {
         deleteMappingPcp(extPort:number) :Promise<boolean>;
 
         probeUpnpSupport() :Promise<boolean>;
-        addMappingUpnp(intPort:number, extPort:number, lifetime:number) :Promise<Mapping>;
+        addMappingUpnp(intPort:number, extPort:number, lifetime:number, 
+                       controlUrl?:string) :Promise<Mapping>;
         deleteMappingUpnp(extPort:number) :Promise<boolean>;
 
         getActiveMappings() :Promise<ActiveMappings>;


### PR DESCRIPTION
Instead of instantiating its own version of `freedom-port-control`, churn now takes in the module as an optional argument in the constructor. This way, we can use only one instance of the module, which is instantiated and stored inside uproxy core.

Everything on the `uproxy-lib` side of this change should be done.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/245)

<!-- Reviewable:end -->
