### PR TITLE
Transformer returns multiple ArrayBuffers from transform and restore

### DIFF
--- a/src/churn-pipe/churn-pipe.ts
+++ b/src/churn-pipe/churn-pipe.ts
@@ -211,7 +211,7 @@ class Pipe {
         this.onIncomingData_(recvFromInfo, publicEndpoint.address, index);
       });
     });
-    
+
     this.publicPorts_[publicEndpoint.address][publicEndpoint.port] = portPromise;
     return portPromise;
   }
@@ -411,12 +411,14 @@ class Pipe {
    * The message is obfuscated before it hits the wire.
    */
   private sendTo_ = (publicSocket:Socket, buffer:ArrayBuffer, to:net.Endpoint)
-      : void => {
-    var transformedBuffer = this.transformer_.transform(buffer);
-    publicSocket.sendTo.reckless(
-      transformedBuffer,
-      to.address,
-      to.port);
+      :void => {
+    var transformedBuffers = this.transformer_.transform(buffer);
+    for(var i=0; i<transformedBuffers.length; i++) {
+      publicSocket.sendTo.reckless(
+        transformedBuffers[i],
+        to.address,
+        to.port);
+    }
   }
 
   /**
@@ -432,12 +434,14 @@ class Pipe {
       return;
     }
     var transformedBuffer = recvFromInfo.data;
-    var buffer = this.transformer_.restore(transformedBuffer);
+    var buffers = this.transformer_.restore(transformedBuffer);
     this.getMirrorSocket_(recvFromInfo, index).then((mirrorSocket:Socket) => {
-      mirrorSocket.sendTo.reckless(
-          buffer,
-          iface,
-          browserPort);
+      for(var i=0; i<buffers.length; i++) {
+        mirrorSocket.sendTo.reckless(
+            buffers[i],
+            iface,
+            browserPort);
+      }
     });
   }
 

--- a/src/churn-pipe/churn-pipe.ts
+++ b/src/churn-pipe/churn-pipe.ts
@@ -413,7 +413,7 @@ class Pipe {
   private sendTo_ = (publicSocket:Socket, buffer:ArrayBuffer, to:net.Endpoint)
       :void => {
     var transformedBuffers = this.transformer_.transform(buffer);
-    for(var i=0; i<transformedBuffers.length; i++) {
+    for(var i = 0; i < transformedBuffers.length; i++) {
       publicSocket.sendTo.reckless(
         transformedBuffers[i],
         to.address,
@@ -436,7 +436,7 @@ class Pipe {
     var transformedBuffer = recvFromInfo.data;
     var buffers = this.transformer_.restore(transformedBuffer);
     this.getMirrorSocket_(recvFromInfo, index).then((mirrorSocket:Socket) => {
-      for(var i=0; i<buffers.length; i++) {
+      for(var i = 0; i < buffers.length; i++) {
         mirrorSocket.sendTo.reckless(
             buffers[i],
             iface,

--- a/src/simple-transformers/caesar.spec.ts
+++ b/src/simple-transformers/caesar.spec.ts
@@ -37,7 +37,7 @@ describe("caesar cipher", function() {
   it('transform buffer', function() {
     setKey(1);
     var bytes = new Uint8Array([4, 1, 255]);
-    var result = new Uint8Array(transformer.transform(bytes.buffer));
+    var result = new Uint8Array(transformer.transform(bytes.buffer)[0]);
     // toEquals() doesn't work for Uint8Array.
     expect(result[0]).toEqual(5);
     expect(result[1]).toEqual(2);
@@ -49,7 +49,7 @@ describe("caesar cipher", function() {
 
     setKey(1);
     var output = new Uint8Array(transformer.restore(
-        transformer.transform(new Uint8Array([4, 1, 255]).buffer)));
+        transformer.transform(new Uint8Array([4, 1, 255]).buffer)[0])[0]);
 
     for (var i = 0; i < output.length; i++) {
       expect(output[i]).toEqual(input[i]);

--- a/src/simple-transformers/caesar.ts
+++ b/src/simple-transformers/caesar.ts
@@ -34,14 +34,14 @@ class CaesarCipher implements Transformer {
   /** Nothing to configure -- all this transformer needs is a key. */
   public configure = (json:string) : void => {}
 
-  public transform = (buffer:ArrayBuffer) : ArrayBuffer => {
+  public transform = (buffer:ArrayBuffer) : ArrayBuffer[] => {
     this.map_(buffer, this.transformByte);
-    return buffer;
+    return [buffer];
   }
 
-  public restore = (buffer:ArrayBuffer) : ArrayBuffer => {
+  public restore = (buffer:ArrayBuffer) : ArrayBuffer[] => {
     this.map_(buffer, this.restoreByte);
-    return buffer;
+    return [buffer];
   }
 
   // No-op (we have no state or any resources to dispose).

--- a/src/simple-transformers/passthrough.ts
+++ b/src/simple-transformers/passthrough.ts
@@ -6,16 +6,18 @@
 /** An obfuscator which does nothing. */
 class PassThrough implements Transformer {
 
+  public constructor() {}
+
   public setKey = (key:ArrayBuffer) => {}
 
   public configure = (json:string) : void => {}
 
-  public transform = (buffer:ArrayBuffer) : ArrayBuffer => {
-    return buffer;
+  public transform = (buffer:ArrayBuffer) : ArrayBuffer[] => {
+    return [buffer];
   }
 
-  public restore = (buffer:ArrayBuffer) : ArrayBuffer => {
-    return buffer;
+  public restore = (buffer:ArrayBuffer) : ArrayBuffer[] => {
+    return [buffer];
   }
 
   public dispose = () : void => {}

--- a/third_party/uTransformers/utransformers.d.ts
+++ b/third_party/uTransformers/utransformers.d.ts
@@ -21,7 +21,11 @@ interface Transformer {
    * Transforms a piece of data to obfuscated form.
    *
    * @param {ArrayBuffer} plaintext data that needs to be obfuscated.
-   * @return {ArrayBuffer[]} array of obfuscated data, empty if failed.
+   * @return {ArrayBuffer[]} list of ArrayBuffers of obfuscated data.
+   * The list can contain zero, one, or more than one items.
+   * In the case of fragmentation:
+   *   When fragmention occurs, the list will have more than one item.
+   *   When there is no fragmentation, the list will have one item.
    */
   transform(buffer:ArrayBuffer) : ArrayBuffer[];
 
@@ -29,7 +33,11 @@ interface Transformer {
    * Restores data from obfuscated form to original form.
    *
    * @param {ArrayBuffer} ciphertext obfuscated data.
-   * @return {ArrayBuffer} array of original data, empty if failed.
+   * @return {ArrayBuffer} list of ArrayBuffers of original data.
+   * The list can contain zero, one, or more than one items.
+   * In the case of fragmentation:
+   *   When receiving a fragment, the list will have zero items,
+   *   unless it was the last fragment, then the list will have one item.
    */
   restore(buffer:ArrayBuffer) : ArrayBuffer[];
 

--- a/third_party/uTransformers/utransformers.d.ts
+++ b/third_party/uTransformers/utransformers.d.ts
@@ -20,18 +20,18 @@ interface Transformer {
   /**
    * Transforms a piece of data to obfuscated form.
    *
-   * @param {ArrayBuffer} plaintext data need to be obfuscated.
-   * @return {?ArrayBuffer} obfuscated data, or null if failed.
+   * @param {ArrayBuffer} plaintext data that needs to be obfuscated.
+   * @return {ArrayBuffer[]} array of obfuscated data, empty if failed.
    */
-  transform(buffer:ArrayBuffer) : ArrayBuffer;
+  transform(buffer:ArrayBuffer) : ArrayBuffer[];
 
   /**
    * Restores data from obfuscated form to original form.
    *
    * @param {ArrayBuffer} ciphertext obfuscated data.
-   * @return {?ArrayBuffer} original data, or null if failed.
+   * @return {ArrayBuffer} array of original data, empty if failed.
    */
-  restore(buffer:ArrayBuffer) : ArrayBuffer;
+  restore(buffer:ArrayBuffer) : ArrayBuffer[];
 
   /**
    * Dispose the transformer.

--- a/third_party/uTransformers/utransformers.d.ts
+++ b/third_party/uTransformers/utransformers.d.ts
@@ -8,14 +8,14 @@ interface Transformer {
    * @param {ArrayBuffer} key session key.
    * @return {boolean} true if successful.
    */
-  setKey(key:ArrayBuffer) : void;
+  setKey(key:ArrayBuffer) :void;
 
   /**
    * Configures this transformer.
    *
    * @param {String} serialized Json string.
    */
-  configure(json:string) : void;
+  configure(json:string) :void;
 
   /**
    * Transforms a piece of data to obfuscated form.
@@ -27,7 +27,7 @@ interface Transformer {
    *   When fragmention occurs, the list will have more than one item.
    *   When there is no fragmentation, the list will have one item.
    */
-  transform(buffer:ArrayBuffer) : ArrayBuffer[];
+  transform(buffer:ArrayBuffer) :ArrayBuffer[];
 
   /**
    * Restores data from obfuscated form to original form.
@@ -39,20 +39,20 @@ interface Transformer {
    *   When receiving a fragment, the list will have zero items,
    *   unless it was the last fragment, then the list will have one item.
    */
-  restore(buffer:ArrayBuffer) : ArrayBuffer[];
+  restore(buffer:ArrayBuffer) :ArrayBuffer[];
 
   /**
    * Dispose the transformer.
    *
    * This should be the last method called on a transformer instance.
    */
-  dispose() : void;
+  dispose() :void;
 }
 
 declare module "utransformers/src/transformers/uTransformers.fte" {
-  export function Transformer() : Transformer;
+  export function Transformer() :Transformer;
 }
 
 declare module "utransformers/src/transformers/uTransformers.rabbit" {
-  export function Transformer() : Transformer;
+  export function Transformer() :Transformer;
 }


### PR DESCRIPTION
The Transformer API has been changed and all of the simple-transformers have been updated to use the new API. churn-pipe has also been updated to handle transformers that return multiple ArrayBuffers.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/250)

<!-- Reviewable:end -->
