### PR TITLE
Reduce heartbeat timeout to 15 seconds.

### DIFF
--- a/src/webrtc/peerconnection.ts
+++ b/src/webrtc/peerconnection.ts
@@ -64,7 +64,7 @@ var CONTROL_CHANNEL_LABEL = '';
 
 // Interval, in milliseconds, after which the peerconnection will
 // terminate if no heartbeat is received from the peer.
-var HEARTBEAT_TIMEOUT_MS_ = 30000;
+var HEARTBEAT_TIMEOUT_MS_ = 15000;
 
 // Interval, in milliseconds, at which heartbeats are sent to the peer.
 var HEARTBEAT_INTERVAL_MS_ = 5000;


### PR DESCRIPTION
Now that uproxy has auto-reconnect, it's probably better to fail
sooner (e.g. to recover from an IP address change), and risk
occasional disconnections under extreme load.

This is intended to mitigate the Firefox disconnection issue: https://github.com/uProxy/uproxy/issues/1803

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/260)

<!-- Reviewable:end -->
