### PR TITLE
Added a transformer that encrypts packets using AES in CBC mode

### DIFF
--- a/src/fancy-transformers/encryptionShaper.ts
+++ b/src/fancy-transformers/encryptionShaper.ts
@@ -51,6 +51,10 @@ export class EncryptionShaper implements Transformer {
   }
 
   public transform = (buffer:ArrayBuffer) :ArrayBuffer[] => {
+    // This transform performs the following steps:
+    // - Generate a new random 16-byte IV for every packet
+    // - Encrypt the packet contents with the random IV and symmetric key
+    // - Concatenate the IV and encrypted packet contents
     var iv :ArrayBuffer=this.makeIV_();
     var encrypted :ArrayBuffer=this.encrypt_(iv, buffer);
     var parts=[iv, encrypted]
@@ -58,6 +62,11 @@ export class EncryptionShaper implements Transformer {
   }
 
   public restore = (buffer:ArrayBuffer) :ArrayBuffer[] => {
+    // This restore performs the following steps:
+    // - Split the first 16 bytes from the rest of the packet
+    //     The two parts are the IV and the encrypted packet contents
+    // - Decrypt the encrypted packet contents with the IV and symmetric key
+    // - Return the decrypted packet contents
     var parts = arraybuffers.split(buffer, 16);
     var iv=parts[0];
     var ciphertext=parts[1];

--- a/src/fancy-transformers/encryptionShaper.ts
+++ b/src/fancy-transformers/encryptionShaper.ts
@@ -49,7 +49,7 @@ export class EncryptionShaper implements Transformer {
     // - Generate a new random 16-byte IV for every packet
     // - Encrypt the packet contents with the random IV and symmetric key
     // - Concatenate the IV and encrypted packet contents
-    var iv :ArrayBuffer=this.makeIV_();
+    var iv :ArrayBuffer=EncryptionShaper.makeIV();
     var encrypted :ArrayBuffer=this.encrypt_(iv, buffer);
     var parts=[iv, encrypted]
     return [arraybuffers.concat(parts)];
@@ -70,7 +70,7 @@ export class EncryptionShaper implements Transformer {
   // No-op (we have no state or any resources to dispose).
   public dispose = () :void => {}
 
-  private makeIV_ = () :ArrayBuffer => {
+  static makeIV = () :ArrayBuffer => {
     var randomBytes=new Uint8Array(16);
     crypto.getRandomValues(randomBytes);
     return randomBytes.buffer;

--- a/src/fancy-transformers/encryptionShaper.ts
+++ b/src/fancy-transformers/encryptionShaper.ts
@@ -1,0 +1,127 @@
+
+// TODO(bwiley): update uTransformers to be compatible with require
+// TODO(ldixon): update to a require-style inclusion.
+// e.g.
+//  import Transformer = require('uproxy-obfuscators/transformer');
+/// <reference path='../../../third_party/uTransformers/utransformers.d.ts' />
+/// <reference path='../../../third_party/typings/webcrypto/WebCrypto.d.ts' />
+/// <reference path='../../../third_party/aes-js/aes-js.d.ts' />
+
+import logging = require('../logging/logging');
+import arraybuffers = require('../arraybuffers/arraybuffers');
+import aes = require('aes-js');
+
+var log :logging.Log = new logging.Log('fancy-transformers');
+
+export interface EncryptionConfig {key:ArrayBuffer}
+export interface SerializedEncryptionConfig {key:string}
+
+// A packet shaper that encrypts the packets with AES CBC.
+export class EncryptionShaper implements Transformer {
+  private key_ :ArrayBuffer;
+
+  public constructor() {
+    log.info('Constructed encryption shaper');
+  }
+
+  // This method is required to implement the Transformer API.
+  // @param {ArrayBuffer} key Key to set, not used by this class.
+  public setKey = (key:ArrayBuffer) :void => {
+    // Do nothing.
+  }
+
+  public configure = (json:string) :void => {
+    log.debug("Configuring encryption shaper");
+
+    try {
+      var config=JSON.parse(json);
+
+      // Required parameter
+      if('key' in config) {
+        var encryptionConfig=this.deserializeConfig_(<SerializedEncryptionConfig>config);
+        this.key_=encryptionConfig.key;
+      } else {
+        log.error('Bad JSON config file');
+        log.error(json);
+        throw new Error("Encryption shaper requires key parameter");
+      }
+    } catch(err) {
+      // This is a common failure mode for transformers as any problem with the
+      // configuration usually results in an exception.
+      log.error("Transformer configure crashed");
+    }
+
+    log.debug("Configured encryption shaper");
+  }
+
+  public transform = (buffer:ArrayBuffer) :ArrayBuffer[] => {
+    var iv :ArrayBuffer=this.makeIV_();
+    var encrypted :ArrayBuffer=this.encrypt_(iv, buffer);
+    var parts=[iv, encrypted]
+    return [arraybuffers.concat(parts)];
+  }
+
+  public restore = (buffer:ArrayBuffer) :ArrayBuffer[] => {
+    var parts = arraybuffers.split(buffer, 16);
+    var iv=parts[0];
+    var ciphertext=parts[1];
+    return [this.decrypt_(iv, ciphertext)];
+  }
+
+  // No-op (we have no state or any resources to dispose).
+  public dispose = () :void => {}
+
+  private deserializeConfig_ = (config:SerializedEncryptionConfig) :EncryptionConfig => {
+    return {key:arraybuffers.hexStringToArrayBuffer(config.key)};
+  }
+
+  private makeIV_ = () :ArrayBuffer => {
+    var randomBytes=new Uint8Array(16);
+    crypto.getRandomValues(randomBytes);
+    return randomBytes.buffer;
+  }
+
+  private encrypt_ = (iv:ArrayBuffer, buffer:ArrayBuffer) :ArrayBuffer => {
+    var len :ArrayBuffer = arraybuffers.encodeShort(buffer.byteLength);
+    var remainder = (len.byteLength + buffer.byteLength) % 16;
+    var plaintext:ArrayBuffer;
+    if (remainder === 0) {
+      plaintext=arraybuffers.concat([len, buffer]);
+    } else {
+      var padding = new Uint8Array(16-remainder);
+      crypto.getRandomValues(padding);
+      plaintext=arraybuffers.concat([len, buffer, padding.buffer]);
+    }
+
+    var cbc = new aes.ModeOfOperation.cbc(new Uint8Array(this.key_), new Uint8Array(iv));
+    var chunks = arraybuffers.chunk(plaintext, 16);
+    for(var x = 0; x < chunks.length; x++) {
+      var plainChunk=arraybuffers.arrayBufferToBuffer(chunks[x]);
+      var cipherChunk=cbc.encrypt(plainChunk);
+      chunks[x]=arraybuffers.bufferToArrayBuffer(cipherChunk);
+    }
+
+    return arraybuffers.concat(chunks);
+  }
+
+  private decrypt_ = (iv:ArrayBuffer, ciphertext:ArrayBuffer) :ArrayBuffer => {
+    var cbc = new aes.ModeOfOperation.cbc(new Uint8Array(this.key_), new Uint8Array(iv));
+    var chunks = arraybuffers.chunk(ciphertext, 16);
+    for(var x = 0; x < chunks.length; x++) {
+      chunks[x]=arraybuffers.bufferToArrayBuffer(cbc.decrypt(arraybuffers.arrayBufferToBuffer(chunks[x])));
+    }
+
+    var plaintext=arraybuffers.concat(chunks);
+
+    var parts = arraybuffers.split(plaintext, 2);
+    var lengthBytes = parts[0];
+    var length = arraybuffers.decodeShort(lengthBytes);
+    var rest = parts[1];
+    if(rest.byteLength > length) {
+      parts=arraybuffers.split(rest, length);
+      return parts[0];
+    } else {
+      return rest;
+    }
+  }
+}

--- a/src/fancy-transformers/encryptionShaper.ts
+++ b/src/fancy-transformers/encryptionShaper.ts
@@ -35,7 +35,7 @@ export class EncryptionShaper implements Transformer {
         log.error(json);
         throw new Error("Encryption shaper requires key parameter");
       }
-    } catch(err) {
+    } catch(e) {
       // This is a common failure mode for transformers as any problem with the
       // configuration usually results in an exception.
       log.error("Transformer configure crashed");

--- a/src/fancy-transformers/encryptionShaper.ts
+++ b/src/fancy-transformers/encryptionShaper.ts
@@ -1,8 +1,3 @@
-
-// TODO(bwiley): update uTransformers to be compatible with require
-// TODO(ldixon): update to a require-style inclusion.
-// e.g.
-//  import Transformer = require('uproxy-obfuscators/transformer');
 /// <reference path='../../../third_party/uTransformers/utransformers.d.ts' />
 /// <reference path='../../../third_party/typings/webcrypto/WebCrypto.d.ts' />
 /// <reference path='../../../third_party/aes-js/aes-js.d.ts' />

--- a/src/fancy-transformers/encryptionShaper.ts
+++ b/src/fancy-transformers/encryptionShaper.ts
@@ -20,9 +20,7 @@ export interface SerializedEncryptionConfig {key:string}
 export class EncryptionShaper implements Transformer {
   private key_ :ArrayBuffer;
 
-  public constructor() {
-    log.info('Constructed encryption shaper');
-  }
+  public constructor() {}
 
   // This method is required to implement the Transformer API.
   // @param {ArrayBuffer} key Key to set, not used by this class.

--- a/src/fancy-transformers/encryptionShaper.ts
+++ b/src/fancy-transformers/encryptionShaper.ts
@@ -27,7 +27,7 @@ export class EncryptionShaper implements Transformer {
       var config = JSON.parse(json);
 
       // Required parameter
-      if('key' in config) {
+      if ('key' in config) {
         var encryptionConfig = <EncryptionConfig>config;
         this.key_ = arraybuffers.hexStringToArrayBuffer(encryptionConfig.key);
       } else {
@@ -112,7 +112,7 @@ export class EncryptionShaper implements Transformer {
     var lengthBytes = parts[0];
     var length = arraybuffers.decodeShort(lengthBytes);
     var rest = parts[1];
-    if(rest.byteLength > length) {
+    if (rest.byteLength > length) {
       parts = arraybuffers.split(rest, length);
       return parts[0];
     } else {

--- a/src/fancy-transformers/encryptionShaper.ts
+++ b/src/fancy-transformers/encryptionShaper.ts
@@ -24,12 +24,12 @@ export class EncryptionShaper implements Transformer {
     log.debug("Configuring encryption shaper");
 
     try {
-      var config=JSON.parse(json);
+      var config = JSON.parse(json);
 
       // Required parameter
       if('key' in config) {
-        var encryptionConfig=<EncryptionConfig>config;
-        this.key_=arraybuffers.hexStringToArrayBuffer(encryptionConfig.key);
+        var encryptionConfig = <EncryptionConfig>config;
+        this.key_ = arraybuffers.hexStringToArrayBuffer(encryptionConfig.key);
       } else {
         log.error('Bad JSON config file');
         log.error(json);
@@ -49,9 +49,9 @@ export class EncryptionShaper implements Transformer {
     // - Generate a new random 16-byte IV for every packet
     // - Encrypt the packet contents with the random IV and symmetric key
     // - Concatenate the IV and encrypted packet contents
-    var iv :ArrayBuffer=EncryptionShaper.makeIV();
-    var encrypted :ArrayBuffer=this.encrypt_(iv, buffer);
-    var parts=[iv, encrypted]
+    var iv :ArrayBuffer = EncryptionShaper.makeIV();
+    var encrypted :ArrayBuffer = this.encrypt_(iv, buffer);
+    var parts = [iv, encrypted]
     return [arraybuffers.concat(parts)];
   }
 
@@ -62,8 +62,8 @@ export class EncryptionShaper implements Transformer {
     // - Decrypt the encrypted packet contents with the IV and symmetric key
     // - Return the decrypted packet contents
     var parts = arraybuffers.split(buffer, 16);
-    var iv=parts[0];
-    var ciphertext=parts[1];
+    var iv = parts[0];
+    var ciphertext = parts[1];
     return [this.decrypt_(iv, ciphertext)];
   }
 
@@ -71,7 +71,7 @@ export class EncryptionShaper implements Transformer {
   public dispose = () :void => {}
 
   static makeIV = () :ArrayBuffer => {
-    var randomBytes=new Uint8Array(16);
+    var randomBytes = new Uint8Array(16);
     crypto.getRandomValues(randomBytes);
     return randomBytes.buffer;
   }
@@ -81,19 +81,19 @@ export class EncryptionShaper implements Transformer {
     var remainder = (len.byteLength + buffer.byteLength) % 16;
     var plaintext:ArrayBuffer;
     if (remainder === 0) {
-      plaintext=arraybuffers.concat([len, buffer]);
+      plaintext = arraybuffers.concat([len, buffer]);
     } else {
       var padding = new Uint8Array(16-remainder);
       crypto.getRandomValues(padding);
-      plaintext=arraybuffers.concat([len, buffer, padding.buffer]);
+      plaintext = arraybuffers.concat([len, buffer, padding.buffer]);
     }
 
     var cbc = new aes.ModeOfOperation.cbc(new Uint8Array(this.key_), new Uint8Array(iv));
     var chunks = arraybuffers.chunk(plaintext, 16);
     for(var x = 0; x < chunks.length; x++) {
-      var plainChunk=arraybuffers.arrayBufferToBuffer(chunks[x]);
-      var cipherChunk=cbc.encrypt(plainChunk);
-      chunks[x]=arraybuffers.bufferToArrayBuffer(cipherChunk);
+      var plainChunk = arraybuffers.arrayBufferToBuffer(chunks[x]);
+      var cipherChunk = cbc.encrypt(plainChunk);
+      chunks[x] = arraybuffers.bufferToArrayBuffer(cipherChunk);
     }
 
     return arraybuffers.concat(chunks);
@@ -103,17 +103,17 @@ export class EncryptionShaper implements Transformer {
     var cbc = new aes.ModeOfOperation.cbc(new Uint8Array(this.key_), new Uint8Array(iv));
     var chunks = arraybuffers.chunk(ciphertext, 16);
     for(var x = 0; x < chunks.length; x++) {
-      chunks[x]=arraybuffers.bufferToArrayBuffer(cbc.decrypt(arraybuffers.arrayBufferToBuffer(chunks[x])));
+      chunks[x] = arraybuffers.bufferToArrayBuffer(cbc.decrypt(arraybuffers.arrayBufferToBuffer(chunks[x])));
     }
 
-    var plaintext=arraybuffers.concat(chunks);
+    var plaintext = arraybuffers.concat(chunks);
 
     var parts = arraybuffers.split(plaintext, 2);
     var lengthBytes = parts[0];
     var length = arraybuffers.decodeShort(lengthBytes);
     var rest = parts[1];
     if(rest.byteLength > length) {
-      parts=arraybuffers.split(rest, length);
+      parts = arraybuffers.split(rest, length);
       return parts[0];
     } else {
       return rest;

--- a/src/fancy-transformers/encryptionShaper.ts
+++ b/src/fancy-transformers/encryptionShaper.ts
@@ -24,9 +24,7 @@ export class EncryptionShaper implements Transformer {
 
   // This method is required to implement the Transformer API.
   // @param {ArrayBuffer} key Key to set, not used by this class.
-  public setKey = (key:ArrayBuffer) :void => {
-    // Do nothing.
-  }
+  public setKey = (key:ArrayBuffer) :void => {}
 
   public configure = (json:string) :void => {
     log.debug("Configuring encryption shaper");

--- a/src/fancy-transformers/encryptionShaper.ts
+++ b/src/fancy-transformers/encryptionShaper.ts
@@ -11,7 +11,7 @@ import aes = require('aes-js');
 import arraybuffers = require('../arraybuffers/arraybuffers');
 import logging = require('../logging/logging');
 
-var log :logging.Log = new logging.Log('fancy-transformers');
+var log :logging.Log = new logging.Log('encryption-shaper');
 
 export interface EncryptionConfig {key:ArrayBuffer}
 export interface SerializedEncryptionConfig {key:string}

--- a/src/fancy-transformers/encryptionShaper.ts
+++ b/src/fancy-transformers/encryptionShaper.ts
@@ -8,8 +8,7 @@ import logging = require('../logging/logging');
 
 var log :logging.Log = new logging.Log('encryption-shaper');
 
-export interface EncryptionConfig {key:ArrayBuffer}
-export interface SerializedEncryptionConfig {key:string}
+export interface EncryptionConfig {key:string}
 
 // A packet shaper that encrypts the packets with AES CBC.
 export class EncryptionShaper implements Transformer {
@@ -29,8 +28,8 @@ export class EncryptionShaper implements Transformer {
 
       // Required parameter
       if('key' in config) {
-        var encryptionConfig=this.deserializeConfig_(<SerializedEncryptionConfig>config);
-        this.key_=encryptionConfig.key;
+        var encryptionConfig=<EncryptionConfig>config;
+        this.key_=arraybuffers.hexStringToArrayBuffer(encryptionConfig.key);
       } else {
         log.error('Bad JSON config file');
         log.error(json);
@@ -70,10 +69,6 @@ export class EncryptionShaper implements Transformer {
 
   // No-op (we have no state or any resources to dispose).
   public dispose = () :void => {}
-
-  private deserializeConfig_ = (config:SerializedEncryptionConfig) :EncryptionConfig => {
-    return {key:arraybuffers.hexStringToArrayBuffer(config.key)};
-  }
 
   private makeIV_ = () :ArrayBuffer => {
     var randomBytes=new Uint8Array(16);

--- a/src/fancy-transformers/encryptionShaper.ts
+++ b/src/fancy-transformers/encryptionShaper.ts
@@ -21,27 +21,15 @@ export class EncryptionShaper implements Transformer {
   public setKey = (key:ArrayBuffer) :void => {}
 
   public configure = (json:string) :void => {
-    log.debug("Configuring encryption shaper");
+    var config = JSON.parse(json);
 
-    try {
-      var config = JSON.parse(json);
-
-      // Required parameter
-      if ('key' in config) {
-        var encryptionConfig = <EncryptionConfig>config;
-        this.key_ = arraybuffers.hexStringToArrayBuffer(encryptionConfig.key);
-      } else {
-        log.error('Bad JSON config file');
-        log.error(json);
-        throw new Error("Encryption shaper requires key parameter");
-      }
-    } catch(e) {
-      // This is a common failure mode for transformers as any problem with the
-      // configuration usually results in an exception.
-      log.error("Transformer configure crashed");
+    // Required parameter
+    if ('key' in config) {
+      var encryptionConfig = <EncryptionConfig>config;
+      this.key_ = arraybuffers.hexStringToArrayBuffer(encryptionConfig.key);
+    } else {
+      throw new Error("Encryption shaper requires key parameter");
     }
-
-    log.debug("Configured encryption shaper");
   }
 
   public transform = (buffer:ArrayBuffer) :ArrayBuffer[] => {

--- a/src/fancy-transformers/encryptionShaper.ts
+++ b/src/fancy-transformers/encryptionShaper.ts
@@ -7,9 +7,9 @@
 /// <reference path='../../../third_party/typings/webcrypto/WebCrypto.d.ts' />
 /// <reference path='../../../third_party/aes-js/aes-js.d.ts' />
 
-import logging = require('../logging/logging');
-import arraybuffers = require('../arraybuffers/arraybuffers');
 import aes = require('aes-js');
+import arraybuffers = require('../arraybuffers/arraybuffers');
+import logging = require('../logging/logging');
 
 var log :logging.Log = new logging.Log('fancy-transformers');
 


### PR DESCRIPTION
The encryption shaper uses AES in CBC mode.
The shared symmetric key is provided in configure().
Each packet includes a random Initialization Vector (IV).
This version does not yet implement packet fragmentation for packets where adding the initialization vector causes the length to exceed the expected MTU.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/261)
<!-- Reviewable:end -->
