### PR TITLE
specify a channel ID, to effectively double the number of possible channels

### DIFF
--- a/src/churn/churn.ts
+++ b/src/churn/churn.ts
@@ -455,7 +455,8 @@ export var filterCandidatesFromSdp = (sdp:string) : string => {
     public openDataChannel = (channelLabel:string,
         options?:freedom_RTCPeerConnection.RTCDataChannelInit)
         : Promise<peerconnection.DataChannel> => {
-      return this.obfuscatedConnection_.openDataChannel(channelLabel);
+          return this.obfuscatedConnection_.openDataChannel(channelLabel,
+              options);
     }
 
     public close = () : Promise<void> => {

--- a/src/pool/pool.ts
+++ b/src/pool/pool.ts
@@ -79,18 +79,17 @@ class LocalPool {
     // TODO: limit the number of channels (probably should be <=256).
     if (this.pool_.length > 0) {
       var channel = this.pool_.shift();
-      log.debug('%1: channel requested, pulled %2 from pool (%3 remaining)',
-          this.name_, channel.getLabel(), this.pool_.length);
+      log.debug('%1: re-using channel %2 (%3/%4)',
+          this.name_, channel.getLabel(), this.pool_.length, this.numChannels_);
       return Promise.resolve(channel);
     } else {
-      log.debug('%1: channel requested, creating new', this.name_);
       return this.openNewChannel_();
     }
   }
 
   // Creates and returns a new channel, wrapping it.
   private openNewChannel_ = () : Promise<PoolChannel> => {
-    this.numChannels_++;
+    log.info('%1: opening channel %2', this.name_, this.numChannels_++);
     return this.pc_.openDataChannel('p' + this.numChannels_, {
       id: this.numChannels_
     }).then((dc:datachannel.DataChannel) => {
@@ -107,8 +106,8 @@ class LocalPool {
       return;
     }
     this.pool_.push(poolChannel);
-    log.debug('%1: returned channel %2 to the pool (new size: %3)',
-        this.name_, poolChannel.getLabel(), this.pool_.length);
+    log.debug('%1: returned channel %2 to the pool (%3/%4)',
+        this.name_, poolChannel.getLabel(), this.pool_.length, this.numChannels_);
   }
 }
 
@@ -210,7 +209,7 @@ class PoolChannel implements datachannel.DataChannel {
   }
 
   private changeState_ = (state:State) : void => {
-    log.debug('%1: Changing state from %2 to %3',
+    log.debug('%1: %2 -> %3',
         this.getLabel(), State[this.state_], State[state]);
     this.state_ = state;
   }

--- a/src/pool/pool.ts
+++ b/src/pool/pool.ts
@@ -90,12 +90,14 @@ class LocalPool {
 
   // Creates and returns a new channel, wrapping it.
   private openNewChannel_ = () : Promise<PoolChannel> => {
-    return this.pc_.openDataChannel('p' + this.numChannels_++).
-        then((dc:datachannel.DataChannel) => {
-          return dc.onceOpened.then(() => {
-            return new PoolChannel(dc);
-          });
-        });
+    this.numChannels_++;
+    return this.pc_.openDataChannel('p' + this.numChannels_, {
+      id: this.numChannels_
+    }).then((dc:datachannel.DataChannel) => {
+      return dc.onceOpened.then(() => {
+        return new PoolChannel(dc);
+      });
+    });
   }
 
   // Resets the channel, making it ready for use again, and adds it


### PR DESCRIPTION
pre-:+1:-ed earlier today by @bemasc, who figured out the fix to `churn.ts`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/263)
<!-- Reviewable:end -->
