### PR TITLE
migrate to TypeScript 1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "request": "^2.53.0",
     "socks5-http-client": "^0.1.6",
     "tsd": "^0.5.7",
-    "typescript": "=1.4.1",
+    "typescript": "~1.5.3",
     "yargs": "^3.0.4"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ipaddr.js": "^0.1.3",
     "request": "^2.53.0",
     "socks5-http-client": "^0.1.6",
-    "tsd": "^0.5.7",
+    "tsd": "^0.6.3",
     "typescript": "~1.5.3",
     "yargs": "^3.0.4"
   },

--- a/src/copypaste-socks/main.core-env.ts
+++ b/src/copypaste-socks/main.core-env.ts
@@ -68,9 +68,7 @@ module copypaste_module {
       model.proxyingState = 'stopped';
     });
     return copypaste;
-  }, (e:Error) : any => {
-    // Explicitly declare return type any to workaround this bug:
-    //   https://github.com/Microsoft/TypeScript/issues/2010
+  }, (e:Error) => {
     console.error('could not load freedom: ' + e.message);
   });
 

--- a/src/crypto/random.ts
+++ b/src/crypto/random.ts
@@ -1,5 +1,3 @@
-/// <reference path='../../../third_party/typings/webcrypto/WebCrypto.d.ts' />
-
 // Small convenience wrapper for WebCrypto random Uint32.
 export function randomUint32() : number {
   var randomArray = new Uint32Array(1);

--- a/src/fancy-transformers/encryptionShaper.ts
+++ b/src/fancy-transformers/encryptionShaper.ts
@@ -1,5 +1,4 @@
 /// <reference path='../../../third_party/uTransformers/utransformers.d.ts' />
-/// <reference path='../../../third_party/typings/webcrypto/WebCrypto.d.ts' />
 /// <reference path='../../../third_party/aes-js/aes-js.d.ts' />
 
 import aes = require('aes-js');

--- a/src/net/counter.ts
+++ b/src/net/counter.ts
@@ -24,9 +24,7 @@ export class Counter {
     return f().then((result:T) => {
       this.after_();
       return result;
-    }, (e:Error) : any => {
-      // Explicitly declare return type any to workaround this bug:
-      //   https://github.com/Microsoft/TypeScript/issues/2010
+    }, (e:Error) => {
       this.after_();
       throw e;
     });

--- a/src/samples/copypaste-freedom-chat/main.core-env.ts
+++ b/src/samples/copypaste-freedom-chat/main.core-env.ts
@@ -14,14 +14,14 @@ interface SignallingMessage {
 
 // Locate all nodes of interest up front here to avoid code clutter later on.
 var answerPanelNode = <HTMLElement>document.getElementById('answerPanel');
-var answerPanel_consumeInboundMessageButtonNode = <HTMLElement>document.getElementById('answerPanel_consumeInboundMessageButton');
-var answerPanel_generateIceCandidatesButton = <HTMLElement>document.getElementById('answerPanel_generateIceCandidatesButton');
+var answerPanel_consumeInboundMessageButtonNode = <HTMLButtonElement>document.getElementById('answerPanel_consumeInboundMessageButton');
+var answerPanel_generateIceCandidatesButton = <HTMLButtonElement>document.getElementById('answerPanel_generateIceCandidatesButton');
 var answerPanel_inboundMessageNode = <HTMLInputElement>document.getElementById('answerPanel_inboundMessage');
 var answerPanel_outboundMessageNode = <HTMLInputElement>document.getElementById('answerPanel_outboundMessage');
 var answerPanel_step2ContainerNode = <HTMLElement>document.getElementById('answerPanel_step2Container');
 
 var offerPanelNode = <HTMLElement>document.getElementById('offerPanel');
-var offerPanel_consumeInboundMessageButtonNode = <HTMLElement>document.getElementById('offerPanel_consumeInboundMessageButton');
+var offerPanel_consumeInboundMessageButtonNode = <HTMLButtonElement>document.getElementById('offerPanel_consumeInboundMessageButton');
 var offerPanel_inboundMessageNode = <HTMLInputElement>document.getElementById('offerPanel_inboundMessage');
 var offerPanel_outboundMessageNode = <HTMLInputElement>document.getElementById('offerPanel_outboundMessage');
 var offerPanel_step2ContainerNode = <HTMLElement>document.getElementById('offerPanel_step2Container');
@@ -32,7 +32,7 @@ var startPanel_answerLinkNode = <HTMLElement>document.getElementById('startPanel
 
 var chatPanelNode = <HTMLElement>document.getElementById('chatPanel');
 var chatPanel_outboundMessageNode = <HTMLInputElement>document.getElementById('chatPanel_outboundMessage');
-var chatPanel_sendMessageButtonNode = <HTMLElement>document.getElementById('chatPanel_sendMessageButton');
+var chatPanel_sendMessageButtonNode = <HTMLButtonElement>document.getElementById('chatPanel_sendMessageButton');
 var chatPanel_inboundMessageNode = <HTMLInputElement>document.getElementById('chatPanel_inboundMessage');
 
 freedom('freedom-module.json', {
@@ -114,7 +114,7 @@ freedom('freedom-module.json', {
   // signalling messages. Enables/disables the corresponding form button, as
   // appropriate. Returns null if the field contents are malformed.
   function parseInboundMessages(inboundMessageField:HTMLInputElement,
-                                consumeMessageButton:HTMLElement)
+                                consumeMessageButton:HTMLButtonElement)
       : SignallingMessage[] {
     var signals :string[] = inboundMessageField.value.trim().split('\n');
 

--- a/src/socks-common/socks-headers.ts
+++ b/src/socks-common/socks-headers.ts
@@ -176,7 +176,11 @@ export function composeAuthHandshakeBuffer(auths:Auth[]) : ArrayBuffer {
   var handshakeBytes = new Uint8Array(auths.length + 2);
   handshakeBytes[0] = VERSION5;
   handshakeBytes[1] = auths.length;
-  handshakeBytes.set(auths, 2);
+  // TODO: Revert to set() when Uint8Array's type definition is fixed in TS1.6:
+  //         https://github.com/Microsoft/TypeScript/issues/3979
+  for (var i = 0; i < auths.length; i++) {
+    handshakeBytes[i + 2] = auths[i];
+  }
   return handshakeBytes.buffer;
 }
 
@@ -387,7 +391,11 @@ export function composeDestination(destination:Destination) : Uint8Array {
     case AddressType.IP_V4:
       addressSize = 4;
       var ipv4 = ipaddr.IPv4.parse(endpoint.address);
-      address.set(ipv4.octets, 1);
+      // TODO: Revert to set() when Uint8Array's type definition is fixed in TS1.6:
+      //         https://github.com/Microsoft/TypeScript/issues/3979
+      for (var i = 0; i < ipv4.octets.length; i++) {
+        address[i + 1] = ipv4.octets[i];
+      }
       break;
     case AddressType.DNS:
       addressSize = endpoint.address.length + 1;
@@ -399,7 +407,12 @@ export function composeDestination(destination:Destination) : Uint8Array {
     case AddressType.IP_V6:
       addressSize = 16;
       var ipv6 = ipaddr.IPv6.parse(endpoint.address);
-      address.set(ipv6.toByteArray(), 1);
+      // TODO: Revert to set() when Uint8Array's type definition is fixed in TS1.6:
+      //         https://github.com/Microsoft/TypeScript/issues/3979
+      var ipv6Bytes = ipv6.toByteArray();
+      for (var i = 0; i < ipv6Bytes.length; i++) {
+        address[i + 1] = ipv6Bytes[i];
+      }
       break;
     default:
       throw new Error(

--- a/src/socks-common/socks-headers.ts
+++ b/src/socks-common/socks-headers.ts
@@ -176,11 +176,8 @@ export function composeAuthHandshakeBuffer(auths:Auth[]) : ArrayBuffer {
   var handshakeBytes = new Uint8Array(auths.length + 2);
   handshakeBytes[0] = VERSION5;
   handshakeBytes[1] = auths.length;
-  // TODO: Revert to set() when Uint8Array's type definition is fixed in TS1.6:
-  //         https://github.com/Microsoft/TypeScript/issues/3979
-  for (var i = 0; i < auths.length; i++) {
-    handshakeBytes[i + 2] = auths[i];
-  }
+  // https://github.com/Microsoft/TypeScript/issues/3979
+  (<any>handshakeBytes).set(auths, 2);
   return handshakeBytes.buffer;
 }
 
@@ -391,11 +388,8 @@ export function composeDestination(destination:Destination) : Uint8Array {
     case AddressType.IP_V4:
       addressSize = 4;
       var ipv4 = ipaddr.IPv4.parse(endpoint.address);
-      // TODO: Revert to set() when Uint8Array's type definition is fixed in TS1.6:
-      //         https://github.com/Microsoft/TypeScript/issues/3979
-      for (var i = 0; i < ipv4.octets.length; i++) {
-        address[i + 1] = ipv4.octets[i];
-      }
+      // https://github.com/Microsoft/TypeScript/issues/3979
+      (<any>address).set(ipv4.octets, 1);
       break;
     case AddressType.DNS:
       addressSize = endpoint.address.length + 1;
@@ -407,12 +401,8 @@ export function composeDestination(destination:Destination) : Uint8Array {
     case AddressType.IP_V6:
       addressSize = 16;
       var ipv6 = ipaddr.IPv6.parse(endpoint.address);
-      // TODO: Revert to set() when Uint8Array's type definition is fixed in TS1.6:
-      //         https://github.com/Microsoft/TypeScript/issues/3979
-      var ipv6Bytes = ipv6.toByteArray();
-      for (var i = 0; i < ipv6Bytes.length; i++) {
-        address[i + 1] = ipv6Bytes[i];
-      }
+      // https://github.com/Microsoft/TypeScript/issues/3979
+      (<any>address).set(ipv6.toByteArray(), 1);
       break;
     default:
       throw new Error(

--- a/third_party/tsd.json
+++ b/third_party/tsd.json
@@ -11,9 +11,6 @@
     "jasmine/jasmine.d.ts": {
       "commit": "675a63e4036624d24b06f1b173a92cbe7bb72ab7"
     },
-    "webcrypto/WebCrypto.d.ts": {
-      "commit": "338059f48e4e32ef11472bd5a54ad91fb67f8c36"
-    },
     "form-data/form-data.d.ts": {
       "commit": "338059f48e4e32ef11472bd5a54ad91fb67f8c36"
     },

--- a/third_party/tsd.json
+++ b/third_party/tsd.json
@@ -6,7 +6,7 @@
   "bundle": "third_party/typings/tsd.d.ts",
   "installed": {
     "es6-promise/es6-promise.d.ts": {
-      "commit": "338059f48e4e32ef11472bd5a54ad91fb67f8c36"
+      "commit": "e5de5c4daf8cdc33ed60704cd6e8021c99a89f92"
     },
     "jasmine/jasmine.d.ts": {
       "commit": "675a63e4036624d24b06f1b173a92cbe7bb72ab7"


### PR DESCRIPTION
Related issue:
https://github.com/uProxy/uproxy/issues/1477

This is for selfish reasons -- I desperately needed ArcticTypeScript back and it now only compiles projects with TS1.5+.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/267)
<!-- Reviewable:end -->
