### PR TITLE
Use ID 0 for the control channel, to avoid collision with the pool.

### DIFF
--- a/src/webrtc/peerconnection.ts
+++ b/src/webrtc/peerconnection.ts
@@ -247,7 +247,7 @@ export class PeerConnectionClass implements PeerConnection<signals.Message> {
     // data channels (without it, we would have to re-negotiate SDP after the
     // PC is established), we start negotaition by openning a data channel to
     // the peer, this triggers the negotiation needed event.
-    return this.pc_.createDataChannel(CONTROL_CHANNEL_LABEL, undefined).then(
+    return this.pc_.createDataChannel(CONTROL_CHANNEL_LABEL, {id: 0}).then(
         this.addRtcDataChannel_).then(
         this.registerControlChannel_).then(() => {
           return this.onceConnected;


### PR DESCRIPTION
This fixes https://github.com/uProxy/uproxy/issues/1859

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/269)

<!-- Reviewable:end -->
