### PR TITLE
Added encryption transformer to churn

### DIFF
--- a/src/churn/churn.ts
+++ b/src/churn/churn.ts
@@ -19,6 +19,7 @@ import arraybuffers = require('../arraybuffers/arraybuffers');
 import candidate = require('./candidate');
 import churn_pipe_types = require('../churn-pipe/freedom-module.interface');
 import churn_types = require('./churn.types');
+import encryption = require('../fancy-transformers/encryptionShaper');
 import handler = require('../handler/queue');
 import ipaddr = require('ipaddr.js');
 import logging = require('../logging/logging');
@@ -240,7 +241,7 @@ export var filterCandidatesFromSdp = (sdp:string) : string => {
                 this.portControl_.addMapping(c.relatedPort, c.port, MAP_LIFETIME).
                   then((mapping:freedom.PortControl.Mapping) => {
                     if (mapping.externalPort === -1) {
-                      log.debug("addMapping() failed. Mapping object: ", 
+                      log.debug("addMapping() failed. Mapping object: ",
                                 mapping);
                     } else {
                       log.debug("addMapping() success: ", mapping);
@@ -305,6 +306,11 @@ export var filterCandidatesFromSdp = (sdp:string) : string => {
       this.pipe_.setTransformer('caesar',
           new Uint8Array([key]).buffer,
           '{}');
+          
+      /*this.pipe_.setTransformer('encryptionShaper',
+        new Uint8Array([key]).buffer,
+        JSON.stringify({'key': this.makeSampleEncryptionKey_()}));*/
+
       // TODO(ldixon): re-enable FTE support instead of caesar cipher.
       //     'fte',
       //     arraybuffers.stringToArrayBuffer('FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF'),


### PR DESCRIPTION
Added encryption transformer configuration block to churn-pipe
Rewrote churn transformer initialization to use string to constructor map instead of if-else block.
Added encryption transformer to churn constructor map.
Alphabetized imports as specified in the style guide.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/280)

<!-- Reviewable:end -->
