### PR TITLE
add a map of obfuscator names to class constructors, for easier config

### DIFF
--- a/src/churn-pipe/churn-pipe.ts
+++ b/src/churn-pipe/churn-pipe.ts
@@ -2,17 +2,6 @@
 /// <reference path='../../../third_party/typings/freedom/freedom-module-env.d.ts' />
 /// <reference path='../../../third_party/typings/es6-promise/es6-promise.d.ts' />
 
-// TODO(ldixon): reorganize the utransformers and rename uproxy-obfuscators.
-// Ideal:
-//  import Transformer = require('uproxy-obfuscators/transformer');
-//  import Rabbit = require('uproxy-obfuscators/rabbit.transformer');
-//  import Fte = require('uproxy-obfuscators/fte.transformer');
-// Current:
-/// <reference path='../../../third_party/uTransformers/utransformers.d.ts' />
-
-// import Rabbit = require('utransformers/src/transformers/uTransformers.fte');
-// import Fte = require('utransformers/src/transformers/uTransformers.rabbit');
-
 import PassThrough = require('../simple-transformers/passthrough');
 import CaesarCipher = require('../simple-transformers/caesar');
 import shaper = require('../fancy-transformers/encryptionShaper');

--- a/src/churn-pipe/churn-pipe.ts
+++ b/src/churn-pipe/churn-pipe.ts
@@ -15,6 +15,7 @@
 
 import PassThrough = require('../simple-transformers/passthrough');
 import CaesarCipher = require('../simple-transformers/caesar');
+import shaper = require('../fancy-transformers/encryptionShaper');
 
 import logging = require('../logging/logging');
 import net = require('../net/net.types');
@@ -43,6 +44,13 @@ var retry_ = <T>(func:() => Promise<T>, delayMs?:number) : Promise<T> => {
   });
 }
 
+// Maps transformer names to class constructors.
+var transformers :{[name:string] : new() => Transformer} = {
+  'caesar': CaesarCipher,
+  'encryptionShaper': shaper.EncryptionShaper,
+  'none': PassThrough
+};
+
 var makeTransformer_ = (
     // Name of transformer to use, e.g. 'rabbit' or 'none'.
     name :string,
@@ -50,21 +58,12 @@ var makeTransformer_ = (
     key ?:ArrayBuffer,
     // JSON-encoded configuration, if any.
     config ?:string)
-  : Transformer => {
-  var transformer :Transformer;
-  // TODO(ldixon): re-enable rabbit and FTE once we can figure out why they
-  // don't load in freedom.
-  /* if (name == 'rabbit') {
-     transformer = Rabbit.Transformer();
-     } else if (name == 'fte') {
-     transformer = Fte.Transformer();
-     } else */ if (name == 'caesar') {
-       transformer = new CaesarCipher();
-     } else if (name == 'none') {
-       transformer = new PassThrough();
-     } else {
-       throw new Error('unknown transformer: ' + name);
-     }
+    : Transformer => {
+  if (!(name in transformers)) {
+    throw new Error('unknown transformer: ' + name);
+  }
+
+  var transformer: Transformer = new transformers[name]();
   if (key) {
     transformer.setKey(key);
   }
@@ -170,6 +169,7 @@ class Pipe {
       key ?:ArrayBuffer,
       config ?:string) : Promise<void> => {
     try {
+      log.info('%1: using %2 transformer', this.name_, transformerName);
       this.transformer_ = makeTransformer_(transformerName, key, config);
       return Promise.resolve<void>();
     } catch (e) {

--- a/src/churn/churn.ts
+++ b/src/churn/churn.ts
@@ -2,19 +2,6 @@
 /// <reference path='../../../third_party/typings/freedom/freedom-module-env.d.ts' />
 /// <reference path='../../../third_party/ipaddrjs/ipaddrjs.d.ts' />
 
-// TODO(ldixon): reorganize the utransformers and rename uproxy-obfuscators.
-// Ideal:
-//  import Transformer = require('uproxy-obfuscators/transformer');
-// Current:
-/// <reference path='../../../third_party/uTransformers/utransformers.d.ts' />
-
-
-// TODO(ldixon): re-enable FTE and regex2dfa. But this time, start with a pre-
-// computed set of DFAs because the regex2dfa.js library is 4MB in size. Also
-// experiment with uglify and zip to see if that size drops significantly.
-//
-// import regex2dfa = require('regex2dfa');
-
 import arraybuffers = require('../arraybuffers/arraybuffers');
 import candidate = require('./candidate');
 import churn_pipe_types = require('../churn-pipe/freedom-module.interface');
@@ -314,17 +301,6 @@ export var filterCandidatesFromSdp = (sdp:string) : string => {
       //     JSON.stringify({
       //       'key': '0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0'
       //     }));
-
-      // TODO(ldixon): re-enable FTE support instead of caesar cipher.
-      //     'fte',
-      //     arraybuffers.stringToArrayBuffer('FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF'),
-      //     JSON.stringify({
-      //       'plaintext_dfa': regex2dfa('^.*$'),
-      //       'plaintext_max_len': 1400,
-      //       // This is equivalent to Rabbit cipher.
-      //       'ciphertext_dfa': regex2dfa('^.*$'),
-      //       'ciphertext_max_len': 1450
-      //     }
     }
 
     private addRemoteCandidate_ = (iceCandidate:RTCIceCandidate) => {

--- a/src/churn/churn.ts
+++ b/src/churn/churn.ts
@@ -25,6 +25,7 @@ import logging = require('../logging/logging');
 import net = require('../net/net.types');
 import peerconnection = require('../webrtc/peerconnection');
 import random = require('../crypto/random');
+import shaper = require('../fancy-transformers/encryptionShaper');
 import signals = require('../webrtc/signals');
 
 import ChurnSignallingMessage = churn_types.ChurnSignallingMessage;
@@ -302,9 +303,18 @@ export var filterCandidatesFromSdp = (sdp:string) : string => {
     private configurePipe_ = (key:number) : void => {
       this.pipe_ = freedom['churnPipe'](this.peerName);
       this.pipe_.on('mappingAdded', this.onMappingAdded_);
+
       this.pipe_.setTransformer('caesar',
           new Uint8Array([key]).buffer,
           '{}');
+
+      // Uncomment this to enable AES-based obfuscation.
+      // this.pipe_.setTransformer('encryptionShaper',
+      //     undefined,
+      //     JSON.stringify({
+      //       'key': '0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0'
+      //     }));
+
       // TODO(ldixon): re-enable FTE support instead of caesar cipher.
       //     'fte',
       //     arraybuffers.stringToArrayBuffer('FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF'),


### PR DESCRIPTION
Based on:
https://github.com/uProxy/uproxy-lib/pull/280

Uncomment the lines in `churn.ts` and you can play with the AES traffic shaper. Works for me in Chrome in Docker and without, although there is some issue with Firefox support.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/281)

<!-- Reviewable:end -->
