### PR TITLE
SignalBatcher, v2

### DIFF
--- a/src/bridge/bridge.spec.ts
+++ b/src/bridge/bridge.spec.ts
@@ -47,6 +47,100 @@ var noMoreCandidatesSignal: peerconnection_types.Message = {
 // Static helpers.
 ////////
 
+describe('isTerminatingSignal', function() {
+  it('ignores messages without signals', () => {
+    expect(bridge.isTerminatingSignal({
+      errorOnLastMessage: true
+    })).toBeFalsy();
+  });
+
+  it('handles non-terminating PLAIN signal', () => {
+    expect(bridge.isTerminatingSignal({
+      signals: {
+        PLAIN: [
+          {
+            type: peerconnection_types.Type.CANDIDATE
+          }
+        ]
+      }
+    })).toBeFalsy();
+  });
+
+  it('handles terminating PLAIN signal', () => {
+    expect(bridge.isTerminatingSignal({
+      signals: {
+        PLAIN: [
+          {
+            type: peerconnection_types.Type.NO_MORE_CANDIDATES
+          }
+        ]
+      }
+    })).toBeTruthy();
+  });
+
+  it('handles non-terminating CHURN signal', () => {
+    expect(bridge.isTerminatingSignal({
+      signals: {
+        CHURN: [
+          {
+            caesar: 94
+          }
+        ]
+      }
+    })).toBeFalsy();
+  });
+
+  it('handles terminating CHURN signal', () => {
+    expect(bridge.isTerminatingSignal({
+      signals: {
+        CHURN: [
+          {
+            webrtcMessage: {
+              type: peerconnection_types.Type.NO_MORE_CANDIDATES
+            }
+          }
+        ]
+      }
+    })).toBeTruthy();
+  });
+
+  it('rejects multiple providers', () => {
+    expect(() => {
+      bridge.isTerminatingSignal({
+        signals: {
+          CHURN: [
+            {
+              caesar: 94
+            }
+          ],
+          HOLO_ICE: [
+            {
+              caesar: 94
+            }
+          ]
+        }
+      });
+    }).toThrow();
+  });
+
+  it('rejects multiple signals', () => {
+    expect(() => {
+      bridge.isTerminatingSignal({
+        signals: {
+          CHURN: [
+            {
+              caesar: 94
+            },
+            {
+              caesar: 94
+            }
+          ]
+        }
+      });
+    }).toThrow();
+  });
+});
+
 describe("makeSingleProviderMessage", function() {
   it('basic', () => {
     var signals = [

--- a/src/bridge/bridge.ts
+++ b/src/bridge/bridge.ts
@@ -78,6 +78,21 @@ export interface SignallingMessage {
 // Static helper functions.
 ////////
 
+// Returns true iff message is a "terminating" message,
+// i.e. NO_MORE_CANDIDATES. This is intended for use in copy/paste
+// scenarios where it's important for the caller to know when
+// signalling is complete.
+export var isTerminatingSignal = (message:SignallingMessage) : boolean => {
+  if (ProviderType[ProviderType.CHURN] in message.signals ||
+      ProviderType[ProviderType.HOLO_ICE] in message.signals) {
+    var providerSignals = message.signals[Object.keys(message.signals)[0]];
+    var churnSignal = <churn_types.ChurnSignallingMessage>providerSignals[0];
+    return churnSignal.webrtcMessage && churnSignal.webrtcMessage.type ===
+        peerconnection_types.Type.NO_MORE_CANDIDATES;
+  }
+  throw new Error('no supported provider type found');
+}
+
 // Constructs a signalling message suitable for the initial offer.
 // Public for testing.
 export var makeSingleProviderMessage = (

--- a/src/bridge/onetime.ts
+++ b/src/bridge/onetime.ts
@@ -20,7 +20,8 @@ export var decode = (encoded:string) : Object[] => {
 
 // Queues objects, invoking a callback with a compressed, base64-encoded
 // string representing a "batch" of the queued objects. Batches are
-// determined by the client via the isTerminating_ function.
+// determined by the client via the isTerminating_ function. Note that
+// the terminating message itself is not included in batches.
 // Intended for use in copy/paste scenarios where the size and number
 // of messages transmitted are crucial.
 // gzip is used for compression.

--- a/src/copypaste-socks/freedom-module.ts
+++ b/src/copypaste-socks/freedom-module.ts
@@ -115,6 +115,9 @@ parentModule.on('validateSignalMessage', (encodedMessage:string) => {
 // modules depending on whether we're acting as the frontend or backend,
 // respectively.
 parentModule.on('handleSignalMessage', (encodedMessage:string) => {
+  // The UI should only call this function once the message has
+  // already been successfully decoded, via validateSignalMessage,
+  // so we don't perform any error checking here.
   var messages = onetime.decode(encodedMessage);
 
   if (socksRtc !== undefined) {

--- a/src/copypaste-socks/freedom-module.ts
+++ b/src/copypaste-socks/freedom-module.ts
@@ -57,8 +57,9 @@ var rtcNet:rtc_to_net.RtcToNet;
 var portControl = freedom['portControl']();
 
 var batcher = new onetime.SignalBatcher<bridge.SignallingMessage>(
-    parentModule.emit.bind(undefined, 'signalForPeer'),
-    bridge.isTerminatingSignal);
+    (signal:bridge.SignallingMessage) => {
+  parentModule.emit('signalForPeer', signal);
+}, bridge.isTerminatingSignal);
 
 var doStart = () => {
   var localhostEndpoint:net.Endpoint = { address: '0.0.0.0', port: 9999 };


### PR DESCRIPTION
When I tried to integrate the current `SignalBatcher` with uProxy, I realised it was going to be horribly inefficient: since uProxy wraps signalling channel messages in `social.PeerMessage` messages, we would have to _re-base64 encode_ the _already base64-encoded_ messages from `SignalBatcher`.

This was wiping out most of the gains from compression, so I've refactored `SignalBatcher` to handle arbitrary objects.

Batching (or "flattening") was the main casualty of this but I ran some tests and it turns out that with compression batching is virtually useless: while in one example batching reduced the raw size of the JSON from 2666 characters to 2173, with gzip compression it's a much tinier reduction from 729 to 711 bytes).

Tested with uProxy.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/283)

<!-- Reviewable:end -->
