### PR TITLE
adventure should run with less logging, for performance purposes

### DIFF
--- a/src/adventure/freedom-module.ts
+++ b/src/adventure/freedom-module.ts
@@ -13,7 +13,7 @@ import tcp = require('../net/tcp');
 var loggingController = freedom['loggingcontroller']();
 loggingController.setDefaultFilter(
     loggingTypes.Destination.console,
-    loggingTypes.Level.debug);
+    loggingTypes.Level.info);
 
 var log :logging.Log = new logging.Log('adventure');
 


### PR DESCRIPTION
I just realised we run a bunch of throughput measurements with logging set to debug...that's probably not ideal. I don't think it makes much difference but why not (I performed a quick test with with `INFO` my throughput changed from 942Kb/sec to 985 which is most likely noise but who knows).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/286)
<!-- Reviewable:end -->
