### PR TITLE
Fixed a bug in byte sequence shaper

### DIFF
--- a/src/fancy-transformers/byteSequenceShaper.ts
+++ b/src/fancy-transformers/byteSequenceShaper.ts
@@ -4,7 +4,7 @@ import arraybuffers = require('../arraybuffers/arraybuffers');
 import logging = require('../logging/logging');
 import random = require('../crypto/random');
 
-let log :logging.Log = new logging.Log('fancy-transformers');
+const log :logging.Log = new logging.Log('fancy-transformers');
 
 // Configuration where the sequences have been encoded as strings.
 // This is the interface that configure() expects as an argument.

--- a/src/fancy-transformers/byteSequenceShaper.ts
+++ b/src/fancy-transformers/byteSequenceShaper.ts
@@ -197,8 +197,11 @@ export class ByteSequenceShaper implements Transformer {
 
   // For a byte sequence, see if there is a matching sequence to remove.
   private findMatchingPacket_ = (sequence:ArrayBuffer) => {
-    for(var i = 0; i < this.removeSequences_.length; i++) {
-      if (arraybuffers.byteEquality(sequence, this.removeSequences_[i].sequence)) {
+    for(let i = 0; i < this.removeSequences_.length; i++) {
+      let model = this.removeSequences_[i];
+      let target = model.sequence;
+      let source = sequence.slice(model.offset, target.byteLength);
+      if (arraybuffers.byteEquality(source, target)) {
         return this.removeSequences_.splice(i, 1);
       }
     }

--- a/src/fancy-transformers/byteSequenceShaper.ts
+++ b/src/fancy-transformers/byteSequenceShaper.ts
@@ -10,42 +10,42 @@ var log :logging.Log = new logging.Log('fancy-transformers');
 // This is the interface that configure() expects as an argument.
 export interface SequenceConfig {
   // Sequences that should be added to the outgoing packet stream.
-  addSequences:SerializedSequenceModel[];
+  addSequences :SerializedSequenceModel[];
 
   // Sequences that should be removed from the incoming packet stream.
-  removeSequences:SerializedSequenceModel[]
+  removeSequences :SerializedSequenceModel[]
 }
 
 // Sequence models where the sequences have been encoded as strings.
 // This is used by the SequenceConfig argument passed to configure().
 export interface SerializedSequenceModel {
   // Index of the packet into the sequence.
-  index:number;
+  index :number;
 
   // Offset of the sequence in the packet.
-  offset:number;
+  offset :number;
 
   // Byte sequence encoded as a string.
-  sequence:string;
+  sequence :string;
 
   // Target packet length.
-  length:number
+  length :number
 }
 
 // Sequence models where the sequences have been decoded as ArrayBuffers.
 // This is used internally by the ByteSequenceShaper.
 export interface SequenceModel {
   // Index of the packet into the stream.
-  index:number;
+  index :number;
 
   // Offset of the sequence in the packet.
-  offset:number;
+  offset :number;
 
   // Byte sequence.
-  sequence:ArrayBuffer;
+  sequence :ArrayBuffer;
 
   // Target packet length.
-  length:number
+  length :number
 }
 
 // An obfuscator that injects byte sequences.
@@ -98,7 +98,7 @@ export class ByteSequenceShaper implements Transformer {
     }
   }
 
-  public transform = (buffer:ArrayBuffer) :ArrayBuffer[] => {
+  public transform = (buffer :ArrayBuffer) :ArrayBuffer[] => {
     // Check if the current index into the packet stream is within the range
     // where a packet injection could possibly occur.
     if (this.outputIndex_ <= this.lastIndex_) {
@@ -131,7 +131,7 @@ export class ByteSequenceShaper implements Transformer {
   }
 
   // Remove injected packets.
-  public restore = (buffer:ArrayBuffer) :ArrayBuffer[] => {
+  public restore = (buffer :ArrayBuffer) :ArrayBuffer[] => {
     var match = this.findMatchingPacket_(buffer);
     if (match !== null) {
       return [];
@@ -144,7 +144,7 @@ export class ByteSequenceShaper implements Transformer {
   public dispose = () :void => {}
 
   // Decode the byte sequences from strings in the config information
-  static deserializeConfig(config:SequenceConfig)
+  static deserializeConfig(config :SequenceConfig)
   :[SequenceModel[], SequenceModel[]] {
     var adds :SequenceModel[] = [];
     var rems :SequenceModel[] = [];
@@ -161,7 +161,7 @@ export class ByteSequenceShaper implements Transformer {
   }
 
   // Decode the byte sequence from a string in the sequence model
-  static deserializeModel(model:SerializedSequenceModel) :SequenceModel {
+  static deserializeModel(model :SerializedSequenceModel) :SequenceModel {
     return {
       index:model.index,
       offset:model.offset,
@@ -171,7 +171,7 @@ export class ByteSequenceShaper implements Transformer {
   }
 
   // Inject packets
-  private inject_ = (results:ArrayBuffer[]) : void => {
+  private inject_ = (results :ArrayBuffer[]) : void => {
     var nextPacket = this.findNextPacket_(this.outputIndex_);
     while(nextPacket !== null) {
       this.outputAndIncrement_(results, this.makePacket_(nextPacket));
@@ -179,13 +179,13 @@ export class ByteSequenceShaper implements Transformer {
     }
   }
 
-  private outputAndIncrement_ = (results:ArrayBuffer[], result:ArrayBuffer) : void => {
+  private outputAndIncrement_ = (results :ArrayBuffer[], result :ArrayBuffer) : void => {
     results.push(result);
     this.outputIndex_ = this.outputIndex_ + 1;
   }
 
   // For an index into the packet stream, see if there is a sequence to inject.
-  private findNextPacket_ = (index:number) => {
+  private findNextPacket_ = (index :number) => {
     for(var i = 0; i < this.addSequences_.length; i++) {
       if (index === this.addSequences_[i].index) {
         return this.addSequences_[i];
@@ -196,7 +196,7 @@ export class ByteSequenceShaper implements Transformer {
   }
 
   // For a byte sequence, see if there is a matching sequence to remove.
-  private findMatchingPacket_ = (sequence:ArrayBuffer) => {
+  private findMatchingPacket_ = (sequence :ArrayBuffer) => {
     for(let i = 0; i < this.removeSequences_.length; i++) {
       let model = this.removeSequences_[i];
       let target = model.sequence;
@@ -210,7 +210,7 @@ export class ByteSequenceShaper implements Transformer {
   }
 
   // With a sequence model, generate a packet to inject into the stream.
-  private makePacket_ = (model:SequenceModel) :ArrayBuffer => {
+  private makePacket_ = (model :SequenceModel) :ArrayBuffer => {
     var parts :ArrayBuffer[] = [];
 
     // Add the bytes before the sequence.

--- a/src/fancy-transformers/byteSequenceShaper.ts
+++ b/src/fancy-transformers/byteSequenceShaper.ts
@@ -4,7 +4,7 @@ import arraybuffers = require('../arraybuffers/arraybuffers');
 import logging = require('../logging/logging');
 import random = require('../crypto/random');
 
-var log :logging.Log = new logging.Log('fancy-transformers');
+let log :logging.Log = new logging.Log('fancy-transformers');
 
 // Configuration where the sequences have been encoded as strings.
 // This is the interface that configure() expects as an argument.
@@ -80,7 +80,7 @@ export class ByteSequenceShaper implements Transformer {
   // Configure the transformer with the byte sequences to inject and the byte
   // sequences to remove.
   public configure = (json:string) :void => {
-    var config = JSON.parse(json);
+    let config = JSON.parse(json);
 
     // Required parameters 'addSequences' and 'removeSequences'
     if ('addSequences' in config && 'removeSequences' in config) {
@@ -99,6 +99,8 @@ export class ByteSequenceShaper implements Transformer {
   }
 
   public transform = (buffer :ArrayBuffer) :ArrayBuffer[] => {
+    let results :ArrayBuffer[] = [];
+
     // Check if the current index into the packet stream is within the range
     // where a packet injection could possibly occur.
     if (this.outputIndex_ <= this.lastIndex_) {
@@ -106,8 +108,6 @@ export class ByteSequenceShaper implements Transformer {
       if (this.outputIndex_ >= this.firstIndex_) {
         // Injection has started and has not finished, so check to see if it is
         // time to inject a packet.
-
-        var results :ArrayBuffer[] = [];
 
         // Inject fake packets before the real packet
         this.inject_(results);
@@ -132,7 +132,7 @@ export class ByteSequenceShaper implements Transformer {
 
   // Remove injected packets.
   public restore = (buffer :ArrayBuffer) :ArrayBuffer[] => {
-    var match = this.findMatchingPacket_(buffer);
+    let match = this.findMatchingPacket_(buffer);
     if (match !== null) {
       return [];
     } else {
@@ -146,14 +146,14 @@ export class ByteSequenceShaper implements Transformer {
   // Decode the byte sequences from strings in the config information
   static deserializeConfig(config :SequenceConfig)
   :[SequenceModel[], SequenceModel[]] {
-    var adds :SequenceModel[] = [];
-    var rems :SequenceModel[] = [];
+    let adds :SequenceModel[] = [];
+    let rems :SequenceModel[] = [];
 
-    for(var i = 0; i < config.addSequences.length; i++) {
+    for(let i = 0; i < config.addSequences.length; i++) {
       adds.push(ByteSequenceShaper.deserializeModel(config.addSequences[i]));
     }
 
-    for(var i = 0; i < config.removeSequences.length; i++) {
+    for(let i = 0; i < config.removeSequences.length; i++) {
       rems.push(ByteSequenceShaper.deserializeModel(config.removeSequences[i]));
     }
 
@@ -172,7 +172,7 @@ export class ByteSequenceShaper implements Transformer {
 
   // Inject packets
   private inject_ = (results :ArrayBuffer[]) : void => {
-    var nextPacket = this.findNextPacket_(this.outputIndex_);
+    let nextPacket = this.findNextPacket_(this.outputIndex_);
     while(nextPacket !== null) {
       this.outputAndIncrement_(results, this.makePacket_(nextPacket));
       nextPacket = this.findNextPacket_(this.outputIndex_);
@@ -186,7 +186,7 @@ export class ByteSequenceShaper implements Transformer {
 
   // For an index into the packet stream, see if there is a sequence to inject.
   private findNextPacket_ = (index :number) => {
-    for(var i = 0; i < this.addSequences_.length; i++) {
+    for(let i = 0; i < this.addSequences_.length; i++) {
       if (index === this.addSequences_[i].index) {
         return this.addSequences_[i];
       }
@@ -211,12 +211,12 @@ export class ByteSequenceShaper implements Transformer {
 
   // With a sequence model, generate a packet to inject into the stream.
   private makePacket_ = (model :SequenceModel) :ArrayBuffer => {
-    var parts :ArrayBuffer[] = [];
+    let parts :ArrayBuffer[] = [];
 
     // Add the bytes before the sequence.
     if (model.offset > 0) {
-      var length = model.offset;
-      var randomBytes = new Uint8Array(length);
+      let length = model.offset;
+      let randomBytes = new Uint8Array(length);
       crypto.getRandomValues(randomBytes);
       parts.push(randomBytes.buffer);
     }
@@ -227,7 +227,7 @@ export class ByteSequenceShaper implements Transformer {
     // Add the bytes after the sequnece
     if (model.offset < model.length) {
       length = model.length - (model.offset + model.sequence.byteLength);
-      var randomBytes = new Uint8Array(length);
+      let randomBytes = new Uint8Array(length);
       crypto.getRandomValues(randomBytes);
       parts.push(randomBytes.buffer);
     }


### PR DESCRIPTION
Fixed a bug in restoring where matching would fail if the offset was not 0 or the packet length was longer than the sequence length.
Updated some type formatting.
Changed var to let.
Fixed one scope error detected by changing var to let.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/292)

<!-- Reviewable:end -->
