### PR TITLE
Fixed a bug in the command parser

### DIFF
--- a/src/adventure/freedom-module.ts
+++ b/src/adventure/freedom-module.ts
@@ -68,22 +68,22 @@ var sendReply = (message:string, connection:tcp.Connection) : void => {
 // to a SocksTotc or RtcToNet instance (and further input is treated as
 // signalling channel messages).
 function serveConnection(connection: tcp.Connection): void {
-  var recvBuffer :ArrayBuffer = new ArrayBuffer(0);
+  let recvBuffer :ArrayBuffer = new ArrayBuffer(0);
 
-  var processCommands = (buffer: ArrayBuffer) : void => {
+  let processCommands = (buffer: ArrayBuffer) : void => {
     recvBuffer=arraybuffers.concat([recvBuffer, buffer]);
-    var index = arraybuffers.indexOf(recvBuffer, arraybuffers.decodeByte(
+    let index = arraybuffers.indexOf(recvBuffer, arraybuffers.decodeByte(
       arraybuffers.stringToArrayBuffer('\n')
     ));
     if (index == -1) {
       connection.dataFromSocketQueue.setSyncNextHandler(processCommands);
     } else {
-      var parts = arraybuffers.split(recvBuffer, index);
-      var line = parts[0];
+      let parts = arraybuffers.split(recvBuffer, index);
+      let line = parts[0];
       recvBuffer = parts[1];
 
       // ''.split(' ') == ['']
-      var verb = arraybuffers.arrayBufferToString(
+      let verb = arraybuffers.arrayBufferToString(
           line).split(' ')[0].trim().toLowerCase();
       switch (verb) {
         case 'get':

--- a/src/adventure/freedom-module.ts
+++ b/src/adventure/freedom-module.ts
@@ -74,7 +74,7 @@ function serveConnection(connection :tcp.Connection) :void {
   let recvBuffer :ArrayBuffer = new ArrayBuffer(0);
 
   let processCommands = (buffer :ArrayBuffer) :void => {
-    recvBuffer=arraybuffers.concat([recvBuffer, buffer]);
+    recvBuffer = arraybuffers.concat([recvBuffer, buffer]);
     let index = arraybuffers.indexOf(recvBuffer, arraybuffers.decodeByte(
       arraybuffers.stringToArrayBuffer('\n')
     ));
@@ -92,7 +92,7 @@ function serveConnection(connection :tcp.Connection) :void {
       var words = sentence.split(' ');
       var verb = words[0].trim().toLowerCase();
 
-      let keepParsing=false;
+      let keepParsing = false;
       switch (verb) {
         case 'get':
           get(connection, (transformerName || transformerConfig) ? {
@@ -105,7 +105,7 @@ function serveConnection(connection :tcp.Connection) :void {
           break;
         case 'ping':
           sendReply('ping', connection);
-          keepParsing=true;
+          keepParsing = true;
           break;
         case 'transform':
           // Sample commands:
@@ -134,11 +134,11 @@ function serveConnection(connection :tcp.Connection) :void {
           } else {
             sendReply('usage: transform (with name|config json)', connection);
           }
-          keepParsing=true;
+          keepParsing = true;
           break;
         case 'xyzzy':
           sendReply('Nothing happens.', connection);
-          keepParsing=true;
+          keepParsing = true;
           break;
         case 'quit':
           connection.close();
@@ -147,7 +147,7 @@ function serveConnection(connection :tcp.Connection) :void {
           if (verb.length > 0) {
             sendReply('I don\'t understand that command. (' + verb + ')', connection);
           }
-          keepParsing=true;
+          keepParsing = true;
       }
 
       if (keepParsing) {

--- a/src/adventure/freedom-module.ts
+++ b/src/adventure/freedom-module.ts
@@ -67,10 +67,10 @@ var sendReply = (message:string, connection:tcp.Connection) : void => {
 // "get" or "give" is received, at which point the connection is handed off
 // to a SocksTotc or RtcToNet instance (and further input is treated as
 // signalling channel messages).
-function serveConnection(connection: tcp.Connection): void {
+function serveConnection(connection :tcp.Connection) :void {
   let recvBuffer :ArrayBuffer = new ArrayBuffer(0);
 
-  let processCommands = (buffer: ArrayBuffer) : void => {
+  let processCommands = (buffer :ArrayBuffer) :void => {
     recvBuffer=arraybuffers.concat([recvBuffer, buffer]);
     let index = arraybuffers.indexOf(recvBuffer, arraybuffers.decodeByte(
       arraybuffers.stringToArrayBuffer('\n')

--- a/src/arraybuffers/arraybuffers.ts
+++ b/src/arraybuffers/arraybuffers.ts
@@ -202,3 +202,15 @@ export function parse(buffer:ArrayBuffer, lengths:number[]) :ArrayBuffer[] {
 
   return parts;
 }
+
+// Finds the index of a character in an ArrayBuffer
+export function indexOf(ab :ArrayBuffer, char :number) :number {
+    var bytes = new Uint8Array(ab);
+    for(var i = 0; i < bytes.length; ++i) {
+      if (bytes[i]==char) {
+        return i;
+      }
+    }
+
+    return -1;
+}

--- a/src/arraybuffers/arraybuffers.ts
+++ b/src/arraybuffers/arraybuffers.ts
@@ -205,8 +205,8 @@ export function parse(buffer:ArrayBuffer, lengths:number[]) :ArrayBuffer[] {
 
 // Finds the index of a character in an ArrayBuffer
 export function indexOf(ab :ArrayBuffer, char :number) :number {
-    var bytes = new Uint8Array(ab);
-    for(var i = 0; i < bytes.length; ++i) {
+    let bytes = new Uint8Array(ab);
+    for(let i = 0; i < bytes.length; ++i) {
       if (bytes[i]==char) {
         return i;
       }


### PR DESCRIPTION
The command parser had a bug where if two commands came in a single TCP read, the parser would break.
This has been changed so that the parser buffer however much data it gets and then splits on newline.
This eliminates the need for a hack in the command generator where a half second sleep is inserted between in command.
I have not tested this code yet as I do not know how to run the adventure sample app.
This is more of an exploratory pull request to bring up the idea of fixing the parser.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/293)

<!-- Reviewable:end -->
