### PR TITLE
remove build/dev from NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,5 @@
 .idea
 .grunt
 .tscache
+build/dev
+


### PR DESCRIPTION
Related issue:
https://github.com/uProxy/uproxy/issues/1839

Cuts the size of the NPM by 50% (~60MB -> ~30MB).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/303)

<!-- Reviewable:end -->
