### PR TITLE
add a social provider for proxying with zork instances

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -12,6 +12,7 @@ taskManager.add 'base', [
   'ts:srcInCoreEnv'
   'browserify:loggingProvider'
   'browserify:churnPipeFreedomModule'
+  'browserify:cloudSocialProviderFreedomModule'
 ]
 
 taskManager.add 'samples', [
@@ -28,9 +29,6 @@ taskManager.add 'samples', [
 # Makes the distribution build.
 taskManager.add 'dist', [
   'base'
-  'samples'
-  'test'
-  'coverage'
   'copy:dist'
 ]
 
@@ -535,6 +533,17 @@ module.exports = (grunt) ->
       copypasteChatFreedomModule: Rule.browserify 'copypaste-chat/freedom-module'
       copypasteSocksFreedomModule: Rule.browserify 'copypaste-socks/freedom-module'
       echoServerFreedomModule: Rule.browserify 'echo/freedom-module'
+      cloudSocialProviderFreedomModule: Rule.browserify('cloud/social/freedom-module', {
+        alias : [
+          # Shims for node's dns and net modules from freedom-social-xmpp,
+          # with a couple of fixes.
+          './src/cloud/social/shim/net.js:net'
+          './src/cloud/social/shim/dns.js:dns'
+          # Subset of ssh2-streams (all except SFTP) which works well in
+          # the browser.
+          './src/cloud/social/alias/ssh2-streams.js:ssh2-streams'
+        ]
+      })
       simpleChatFreedomModule: Rule.browserify 'simple-chat/freedom-module'
       simpleSocksFreedomModule: Rule.browserify 'simple-socks/freedom-module'
       simpleTurnFreedomModule: Rule.browserify 'simple-turn/freedom-module'

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -29,6 +29,9 @@ taskManager.add 'samples', [
 # Makes the distribution build.
 taskManager.add 'dist', [
   'base'
+  'samples'
+  'test'
+  'coverage'
   'copy:dist'
 ]
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "jasmine-core": "^2.3.4",
     "request": "^2.53.0",
     "socks5-http-client": "^0.1.6",
+    "ssh2": "^0.4.11",
     "tsd": "^0.6.5",
     "typescript": "^1.6.2",
     "yargs": "^3.0.4"

--- a/src/cloud/social/alias/ssh2-streams.js
+++ b/src/cloud/social/alias/ssh2-streams.js
@@ -1,0 +1,11 @@
+// This is identical to ssh2-streams' index.js except for SFTPStream.
+// We do this because sftp.js contains a call to process.bindings
+// that raises an error in the browser. This is safe because we don't
+// actually care about using SFTP, it's just that ssh2's Client sets
+// some constants to point to some of SFTPStream's constants.
+module.exports = {
+  SFTPStream: {},
+  SSH2Stream: require('ssh2/node_modules/ssh2-streams/lib/ssh'),
+  utils: require('ssh2/node_modules/ssh2-streams/lib/utils'),
+  constants: require('ssh2/node_modules/ssh2-streams/lib/constants')
+};

--- a/src/cloud/social/alias/ssh2-streams.js
+++ b/src/cloud/social/alias/ssh2-streams.js
@@ -5,7 +5,7 @@
 // some constants to point to some of SFTPStream's constants.
 module.exports = {
   SFTPStream: {},
-  SSH2Stream: require('ssh2/node_modules/ssh2-streams/lib/ssh'),
-  utils: require('ssh2/node_modules/ssh2-streams/lib/utils'),
-  constants: require('ssh2/node_modules/ssh2-streams/lib/constants')
+  SSH2Stream: require('ssh2-streams/lib/ssh'),
+  utils: require('ssh2-streams/lib/utils'),
+  constants: require('ssh2-streams/lib/constants')
 };

--- a/src/cloud/social/freedom-module.json
+++ b/src/cloud/social/freedom-module.json
@@ -1,0 +1,125 @@
+{
+  "name": "Cloud Social Provider",
+  "description": "Exposes Zork instances as friends.",
+  "app": {
+    "script": [
+      "freedom-module.static.js"
+    ]
+  },
+  "default": "social2",
+  "provides": [
+    "social2"
+  ],
+  "api": {
+    "social2": {
+      "login": {
+        "type": "method",
+        "value": [{
+          "agent": "string",
+          "version": "string",
+          "url": "string",
+          "interactive": "boolean",
+          "rememberLogin": "boolean"
+        }],
+        "ret": {
+          "userId": "string",
+          "clientId": "string",
+          "status": "string",
+          "timestamp": "number"
+        }
+      },
+
+      "sendMessage": {
+        "type": "method",
+        "value": ["string", "string"]
+      },
+
+      "clearCachedCredentials": {
+        "type": "method",
+        "value": []
+      },
+
+      "getUsers": {
+        "type": "method",
+        "value": [],
+        "ret": "object"
+      },
+
+      "getClients": {
+        "type": "method",
+        "value": [],
+        "ret": "object"
+      },
+
+      "logout": {
+        "type": "method",
+        "value": []
+      },
+
+      "inviteUser": {
+        "type": "method",
+        "value": ["string"],
+        "ret": "Object"
+      },
+
+      "acceptUserInvitation": {
+        "type": "method",
+        "value": ["string"]
+      },
+
+      "blockUser": {
+       "type": "method",
+        "value": [{
+          "userId": "string"
+        }]
+      },
+
+      "removeUser": {
+       "type": "method",
+        "value": [ "string"]
+      },
+
+      "onMessage": {
+        "type": "event",
+        "value": {
+          "from": {
+            "userId": "string",
+            "clientId": "string",
+            "status": "string",
+            "lastUpdated": "number",
+            "lastSeen": "number"
+          },
+          "message": "string"
+        }
+      },
+
+      "onUserProfile": {
+        "type": "event",
+        "value": {
+          "userId": "string",
+          "lastUpdated": "number",
+          "name": "string",
+          "url": "string",
+          "imageData": "string",
+          "status": "number"
+        }
+      },
+
+      "onClientState": {
+        "type": "event",
+        "value": {
+          "userId": "string",
+          "clientId": "string",
+          "status": "string",
+          "lastUpdated": "number",
+          "lastSeen": "number"
+        }
+      }
+    }
+  },
+  "permissions": [
+    "core.tcpsocket",
+    "core.udpsocket",
+    "core.storage"
+  ]
+}

--- a/src/cloud/social/freedom-module.ts
+++ b/src/cloud/social/freedom-module.ts
@@ -1,0 +1,7 @@
+/// <reference path='../../../../third_party/typings/freedom/freedom-module-env.d.ts' />
+
+import provider = require('./provider');
+
+if (typeof freedom !== 'undefined') {
+  freedom().providePromises(provider.CloudSocialProvider);
+}

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -18,10 +18,11 @@ const SSH_SERVER_PASSWORD = 'giver';
 const ZORK_HOST = 'zork';
 const ZORK_PORT = 9000;
 
-// TODO: what is the namespace for storage keys?
+// Key under which our contacts are saved in storage.
 const STORAGE_KEY = 'cloud-social-contacts';
 
-// Placed in storage under STORAGE_KEY.
+// Type of the object placed, in serialised form, in storage
+// under STORAGE_KEY.
 interface SavedContacts {
   addresses?: string[];
 }

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -1,0 +1,459 @@
+/// <reference path='../../../../third_party/typings/es6-promise/es6-promise.d.ts' />
+/// <reference path='../../../../third_party/typings/freedom/freedom-module-env.d.ts' />
+/// <reference path='../../../../third_party/typings/node/node.d.ts' />
+/// <reference path='../../../../third_party/typings/ssh2/ssh2.d.ts' />
+
+import logging = require('../../logging/logging');
+
+// https://github.com/borisyankov/DefinitelyTyped/blob/master/ssh2/ssh2-tests.ts
+import * as ssh2 from 'ssh2';
+var Client = require('ssh2').Client;
+
+var log: logging.Log = new logging.Log('cloud social');
+
+const SSH_SERVER_PORT = 5000;
+const SSH_SERVER_USERNAME = 'giver';
+const SSH_SERVER_PASSWORD = 'giver';
+
+const ZORK_HOST = 'zork';
+const ZORK_PORT = 9000;
+
+// TODO: what is the namespace for storage keys?
+const STORAGE_KEY = 'cloud-social-contacts';
+
+// Placed in storage under STORAGE_KEY.
+interface SavedContacts {
+  addresses?: string[];
+}
+
+// Returns a VersionedPeerMessage, as defined in interfaces/social.ts
+// in the uProxy repo.
+//
+// type is a PeerMessageType value (also defined in that file) and
+// payload is an arbitrary payload, e.g. an instance message.
+// TODO: use typings from the uProxy repo
+function makeVersionedPeerMessage(
+    type:number,
+    payload:Object) : any {
+  return {
+    type: type,
+    data: payload,
+    // TODO: remote-instance assumes client versions >= 5 can do PGP, yuck
+    version: 4
+  };
+}
+
+// Returns an InstanceHandshake, as defined in interfaces/social.ts
+// in the uProxy repo.
+//
+// publicKey is deliberately omitted so that uProxy will consider us
+// an older client without PGP support and will avoid encrypting
+// signalling messages (unnecessary because we are forwarding all the
+// messages over an SSH tunnel).
+// TODO: use typings from the uProxy repo
+function makeInstanceMessage(address:string): any {
+  return {
+    instanceId: address,
+    // Shown in the contacts list while the user's list item is expanded
+    // TODO: show machine details, e.g. Linux (via uname)
+    description: address,
+    consent: {
+      isRequesting: false,
+      isOffering: true
+    },
+    name: address,
+    userId: address
+  };
+}
+
+// To see how these fields are handled, see
+// generic_core/social.ts#handleClient in the uProxy repo.
+function makeClientState(address: string): freedom.Social.ClientState {
+  return {
+    userId: address,
+    clientId: address,
+    // https://github.com/freedomjs/freedom/blob/master/interface/social.json
+    status: 'ONLINE',
+    timestamp: Date.now()
+  };
+}
+
+// To see how these fields are handled, see
+// generic_core/social.ts#handleUserProfile in the uProxy repo. We omit
+// the status field since remote-user.ts#update will use FRIEND as a default.
+function makeUserProfile(address: string): freedom.Social.UserProfile {
+  return {
+    userId: address,
+    name: address
+  };
+}
+
+// Exposes Zork instances as friends.
+//
+// Intended for use with the run_cloud.sh script in the uproxy-docker
+// repo, which will spin up the expected configuration:
+//  - an SSH server running on port 5000, with an account named
+//    "giver" having the password "giver"
+//  - a Zork instance, accessible from the SSH server at the
+//    hostname "zork"
+//
+// Note that since there's no actual uProxy instance running on the
+// cloud instance, we are forced to re-implement some of uProxy's
+// social code here, namely:
+//  - we must send a "fake" INSTANCE message in order for uProxy
+//    to consider the cloud instance online
+//  - we have to inspect, wrap, and unwrap messages coming back and
+//    forth since Zork has its own protocol
+//
+// Additionally, contacts are saved to storage so that we can contact
+// them on login and emit a fake instance message for them, making
+// them appear online.
+//
+// TODO: key-based authentication
+// TODO: move the social message parsing stuff into Zork
+export class CloudSocialProvider {
+  // SSH connections.
+  // TODO: what is a legal client ID?
+  private clients_: { [clientId: string]: Promise<Connection> } = {};
+
+  private storage_: freedom.Storage.Storage = freedom['core.storage']();
+
+  private savedAddresses_: string[] = [];
+
+  constructor(private dispatchEvent_: (name: string, args: Object) => void) {}
+
+  // Emits UserProfile and Instance messages, causing uProxy to make
+  // the friend appear online.
+  private notifyOfUser_ = (address: string) => {
+    this.dispatchEvent_('onUserProfile', makeUserProfile(address));
+    this.dispatchEvent_('onMessage', {
+      from: makeClientState(address),
+      // INSTANCE
+      message: JSON.stringify(makeVersionedPeerMessage(
+        3000, makeInstanceMessage(address)))
+    });
+  }
+
+  // Establishes an SSH connection to a server, first shutting down
+  // any that previously exists.
+  private reconnect_ = (address: string): Promise<Connection> => {
+    log.debug('reconnecting to %1', address);
+    if (address in this.clients_) {
+      log.debug('closing old connection to %1', address);
+      this.clients_[address].then((connection: Connection) => {
+        connection.close();
+      });
+    }
+
+    var connection = new Connection(address, (message: Object) => {
+      this.dispatchEvent_('onMessage', {
+        from: makeClientState(address),
+        // SIGNAL_FROM_SERVER_PEER,
+        message: JSON.stringify(makeVersionedPeerMessage(3002, message))
+      });
+    });
+
+    this.clients_[address] = connection.connect().then(() => {
+      log.info('connected to zork on %1', address);
+
+      if (this.savedAddresses_.indexOf(address) === -1) {
+        this.savedAddresses_.push(address);
+        this.saveContacts_();
+      }
+
+      return connection;
+    });
+
+    return this.clients_[address];
+  }
+
+  // Loads contacts from storage and emits an instance message for each.
+  // This makes all of the stored contacts appear online.
+  private loadContacts_ = () => {
+    log.debug('loadContacts');
+    this.storage_.get(STORAGE_KEY).then((v: string) => {
+      if (!v) {
+        log.debug('no saved contacts');
+        return;
+      }
+      log.debug('loaded contacts: %1', v);
+      try {
+        var savedContacts: SavedContacts = JSON.parse(v);
+        // Dumb attempt to prevent dupes, in lieu of Set.
+        for (let address of savedContacts.addresses) {
+          if (this.savedAddresses_.indexOf(address) === -1) {
+            this.savedAddresses_.push(address);
+            this.notifyOfUser_(address);
+          }
+        }
+      } catch (e) {
+        log.error('could not parse saved contacts: %1', e.message);
+      }
+    }, (e: Error) => {
+      log.error('could not load contacts: %1', e);
+    });
+  }
+
+  // Saves contacts to storage.
+  private saveContacts_ = () => {
+    log.debug('saveContacts');
+    this.storage_.set(STORAGE_KEY, JSON.stringify(<SavedContacts>{
+      addresses: this.savedAddresses_
+    })).then((unused: string) => {
+      log.debug('saved contacts');
+    }, (e: Error) => {
+      log.error('could not save contacts: %1', e);
+    });
+  }
+
+  public login = (options: freedom.Social.LoginRequest):
+      Promise<freedom.Social.ClientState> => {
+    log.debug('login: %1', options);
+    this.loadContacts_();
+    // TODO: base this on the user's public key?
+    //       (shown in the "connected accounts" page)
+    return Promise.resolve(makeClientState('me'));
+  }
+
+  public sendMessage = (destinationClientId: string, message: string): Promise<void> => {
+    log.debug('sendMessage to %1: %2', destinationClientId, message);
+    try {
+      // Messages are serialised VersionedPeerMessages. We need to extract
+      // the signalling message, which is all Zork understands.
+      var versionedPeerMessage: any = JSON.parse(message);
+      if (versionedPeerMessage.type &&
+          versionedPeerMessage.type === 3001 && // social.PeerMessageType.SIGNAL_FROM_CLIENT_PEER
+          versionedPeerMessage.data) {
+        // payload is either an instance of social.ts#SignallingMetadata
+        // or is an opaque object we should forward to Zork.
+        var payload = versionedPeerMessage.data;
+        if (payload.proxyingId) {
+          // Reset the SSH connection because Zork only supports one
+          // proxyng session per connection.
+          log.info('new proxying session %1', payload.proxyingId);
+          if (!(destinationClientId in this.clients_)) {
+            log.info('no previous connection to client %1', destinationClientId);
+          }
+          return this.reconnect_(destinationClientId).then(
+              (connection: Connection) => {
+            connection.sendMessage('give');
+          });
+        } else {
+          if (destinationClientId in this.clients_) {
+            return this.clients_[destinationClientId].then(
+                (connection: Connection) => {
+              connection.sendMessage(JSON.stringify(payload));
+            });
+          } else {
+            return Promise.reject('unknown client ' + destinationClientId);
+          }
+        }
+      } else {
+        return Promise.reject('message has no or wrong type field');
+      }
+    } catch (e) {
+      return Promise.reject('could not de-serialise message: ' + e.message);
+    }
+  }
+
+  public clearCachedCredentials = (): Promise<void> => {
+    log.warn('clearCachedCredentials');
+    return Promise.resolve<void>();
+  }
+
+  public getUsers = (): Promise<freedom.Social.Users> => {
+    log.warn('getUsers');
+    return Promise.resolve();
+  }
+
+  public getClients = (): Promise<freedom.Social.Clients> => {
+    log.warn('getClients');
+    return Promise.resolve();
+  }
+
+  public logout = (): Promise<void> => {
+    log.warn('logout');
+    return Promise.resolve<void>();
+  }
+
+  ////
+  // social2
+  ////
+
+  public inviteUser = (address: string): Promise<Object> => {
+    log.debug('inviteUser %1', address);
+    return this.reconnect_(address).then(() => {
+      this.notifyOfUser_(address);
+      // TODO: what should i return?
+      return Promise.resolve({
+        networkData: '{}'
+      });
+    });
+  }
+
+  public acceptUserInvitation = (userId: string): Promise<void> => {
+    log.warn('acceptUserInvitation: %1', userId);
+    return Promise.resolve<void>();
+  }
+
+  public blockUser = (userId: string): Promise<void> => {
+    log.warn('blockUser %1', userId);
+    return Promise.resolve<void>();
+  }
+
+  public removeUser = (userId: string): Promise<void> => {
+    log.warn('removeUser %1', userId);
+    return Promise.resolve<void>();
+  }
+}
+
+enum ConnectionState {
+  NEW,
+  CONNECTING,
+  ESTABLISHING_TUNNEL,
+  WAITING_FOR_PING,
+  ESTABLISHED,
+  TERMINATED
+}
+
+class Connection {
+  // Number of instances created, for logging purposes.
+  private static id_ = 0;
+
+  private state_ = ConnectionState.NEW;
+
+  private client_ = new Client();
+
+  // The tunneled connection, i.e. secure link to Zork.
+  private stream_ :ssh2.Channel;
+
+  constructor(
+      private address_: string,
+      private send_: (message:Object) => void,
+      private name_: string = 'tunnel' + Connection.id_++) {}
+
+  // TODO: timeout
+  public connect = (): Promise<void> => {
+    if (this.state_ !== ConnectionState.NEW) {
+      return Promise.reject('can only connect in NEW state');
+    }
+    this.state_ = ConnectionState.CONNECTING;
+
+    return new Promise<void>((F, R) => {
+      this.client_.on('ready', () => {
+        this.setState_(ConnectionState.ESTABLISHING_TUNNEL);
+        this.client_.forwardOut(
+          // TODO: since we communicate using the stream, what does this mean?
+          '127.0.0.1', 0,
+          ZORK_HOST, ZORK_PORT, (e: Error, stream: ssh2.Channel) => {
+            if (e) {
+              log.warn('%1: error establishing tunnel: %2',
+                  this.name_, e.toString());
+              this.close();
+              throw e;
+            }
+            this.setState_(ConnectionState.WAITING_FOR_PING);
+
+            this.stream_ = stream;
+
+            // TODO: add error handler for stream
+            this.stream_.on('data', (data: Buffer) => {
+              var reply = data.toString().trim();
+              switch (this.state_) {
+                case ConnectionState.WAITING_FOR_PING:
+                  if (reply === 'ping') {
+                    this.setState_(ConnectionState.ESTABLISHED);
+                    F();
+                  } else {
+                    this.close();
+                    R(new Error('did not receive ping from server on login: ' +
+                        reply));
+                  }
+                  break;
+                case ConnectionState.ESTABLISHED:
+                  try {
+                    this.send_(JSON.parse(reply));
+                  } catch (e) {
+                    log.warn('%1: could not de-serialise signalling message: %2',
+                        this.address_, reply);
+                  }
+                  break;
+                default:
+                  log.warn('%1: did not expect message in state %2: %3',
+                      this.name_, ConnectionState[this.state_], reply);
+                  this.close();
+              }
+            }).on('error', (e: Error) => {
+              // This occurs when:
+              //  - host cannot be reached, e.g. non-existant hostname
+              // TODO: does this occur outside of startup, i.e. should it always reject?
+              log.warn('%1: tunnel error: %2', this.name_, e);
+              this.close();
+              R(new Error('could not establish tunnel: ' + e.toString()));
+            }).on('end', () => {
+              // Occurs when the stream is "over" for any reason, including
+              // failed connection.
+              log.debug('%1: tunnel end', this.name_);
+              this.close();
+            }).on('close', (hadError: boolean) => {
+              // TODO: when does this occur? don't see it on normal close or failure
+              log.debug('%1: tunnel close: %2', this.name_, hadError);
+              this.close();
+            });
+
+            stream.write('ping\n');
+          });
+      }).on('error', (e: Error) => {
+        // This occurs when:
+        //  - user supplies the wrong username or password
+        //  - host cannot be reached, e.g. non-existant hostname
+        // TODO: does this occur outside of startup, i.e. should it always reject?
+        log.warn('%1: connection error: %2', this.name_, e);
+        this.close();
+        R(new Error('could not login: ' + e.toString()));
+      }).on('end', () => {
+        // Occurs when the connection is "over" for any reason, including
+        // failed connection.
+        log.debug('%1: connection ended', this.name_);
+        this.close();
+      }).on('close', (hadError: boolean) => {
+        // TODO: when does this occur? don't see it on normal close or failure
+        log.debug('%1: connection close: %2', this.name_, hadError);
+        this.close();
+      }).connect({
+        host: this.address_,
+        port: SSH_SERVER_PORT,
+        username: SSH_SERVER_USERNAME,
+        password: SSH_SERVER_PASSWORD
+      });
+    });
+  }
+
+  public sendMessage = (s: string): void => {
+    if (this.state_ !== ConnectionState.ESTABLISHED) {
+      throw new Error('can only connect in ESTABLISHED state');
+    }
+    this.stream_.write(s + '\n');
+  }
+
+  public close = (): void => {
+    log.debug('%1: close', this.name_);
+    if (this.state_ === ConnectionState.TERMINATED) {
+      log.debug('%1: already closed', this.name_);
+    } else {
+      this.setState_(ConnectionState.TERMINATED);
+      this.client_.end();
+      // TODO: what about the stream?
+    }
+  }
+
+  private setState_ = (newState: ConnectionState) => {
+    log.debug('%1: %2 -> %3', this.name_, ConnectionState[this.state_],
+      ConnectionState[newState]);
+    this.state_ = newState;
+  }
+
+  public getState = (): ConnectionState => {
+    return this.state_;
+  }
+}

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -211,6 +211,7 @@ export class CloudSocialProvider {
       Promise<freedom.Social.ClientState> => {
     log.debug('login: %1', options);
     this.loadContacts_();
+    // TODO: emit an onUserProfile event, which can include an image URL
     // TODO: base this on the user's public key?
     //       (shown in the "connected accounts" page)
     return Promise.resolve(makeClientState('me'));

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -172,14 +172,14 @@ export class CloudSocialProvider {
   // This makes all of the stored contacts appear online.
   private loadContacts_ = () => {
     log.debug('loadContacts');
-    this.storage_.get(STORAGE_KEY).then((v: string) => {
-      if (!v) {
+    this.storage_.get(STORAGE_KEY).then((storedString: string) => {
+      if (!storedString) {
         log.debug('no saved contacts');
         return;
       }
-      log.debug('loaded contacts: %1', v);
+      log.debug('loaded contacts: %1', storedString);
       try {
-        var savedContacts: SavedContacts = JSON.parse(v);
+        var savedContacts: SavedContacts = JSON.parse(storedString);
         // Dumb attempt to prevent dupes, in lieu of Set.
         for (let address of savedContacts.addresses) {
           if (this.savedAddresses_.indexOf(address) === -1) {

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -275,7 +275,12 @@ export class CloudSocialProvider {
   }
 
   public logout = (): Promise<void> => {
-    log.warn('logout');
+    log.debug('logout');
+    for (let address in this.clients_) {
+      this.clients_[address].then((connection: Connection) => {
+        connection.close();
+      });
+    }
     return Promise.resolve<void>();
   }
 

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -332,7 +332,7 @@ class Connection {
 
   constructor(
       private address_: string,
-      private send_: (message:Object) => void,
+      private received_: (message:Object) => void,
       private name_: string = 'tunnel' + Connection.id_++) {}
 
   // TODO: timeout
@@ -375,7 +375,7 @@ class Connection {
                   break;
                 case ConnectionState.ESTABLISHED:
                   try {
-                    this.send_(JSON.parse(reply));
+                    this.received_(JSON.parse(reply));
                   } catch (e) {
                     log.warn('%1: could not de-serialise signalling message: %2',
                         this.address_, reply);

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -231,6 +231,8 @@ export class CloudSocialProvider {
         if (payload.proxyingId) {
           // Reset the SSH connection because Zork only supports one
           // proxyng session per connection.
+          // TODO: Do not reconnect if we have just invited
+          //       the instance (safe because all we've done is run ping).
           log.info('new proxying session %1', payload.proxyingId);
           if (!(destinationClientId in this.clients_)) {
             log.info('no previous connection to client %1', destinationClientId);

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -287,10 +287,7 @@ export class CloudSocialProvider {
     log.debug('inviteUser %1', address);
     return this.reconnect_(address).then(() => {
       this.notifyOfUser_(address);
-      // TODO: what should i return?
-      return Promise.resolve({
-        networkData: '{}'
-      });
+      return Promise.resolve();
     });
   }
 

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -260,18 +260,18 @@ export class CloudSocialProvider {
   }
 
   public clearCachedCredentials = (): Promise<void> => {
-    log.warn('clearCachedCredentials');
-    return Promise.resolve<void>();
+    return Promise.reject(
+        new Error('clearCachedCredentials unimplemented'));
   }
 
   public getUsers = (): Promise<freedom.Social.Users> => {
-    log.warn('getUsers');
-    return Promise.resolve();
+    return Promise.reject(
+        new Error('getUsers unimplemented'));
   }
 
   public getClients = (): Promise<freedom.Social.Clients> => {
-    log.warn('getClients');
-    return Promise.resolve();
+    return Promise.reject(
+        new Error('getClients unimplemented'));
   }
 
   public logout = (): Promise<void> => {
@@ -295,18 +295,18 @@ export class CloudSocialProvider {
   }
 
   public acceptUserInvitation = (userId: string): Promise<void> => {
-    log.warn('acceptUserInvitation: %1', userId);
-    return Promise.resolve<void>();
+    return Promise.reject(
+        new Error('acceptUserInvitation unimplemented'));
   }
 
   public blockUser = (userId: string): Promise<void> => {
-    log.warn('blockUser %1', userId);
-    return Promise.resolve<void>();
+    return Promise.reject(
+        new Error('blockUser unimplemented'));
   }
 
   public removeUser = (userId: string): Promise<void> => {
-    log.warn('removeUser %1', userId);
-    return Promise.resolve<void>();
+    return Promise.reject(
+        new Error('removeUser unimplemented'));
   }
 }
 

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -123,12 +123,17 @@ export class CloudSocialProvider {
 
   constructor(private dispatchEvent_: (name: string, args: Object) => void) {}
 
-  // Emits UserProfile and Instance messages, causing uProxy to make
-  // the friend appear online.
+  // Emits the messages necessary to make the user appear online 
+  // in the contacts list.
   private notifyOfUser_ = (address: string) => {
     this.dispatchEvent_('onUserProfile', makeUserProfile(address));
+
+    var clientState = makeClientState(address);
+    this.dispatchEvent_('onClientState', clientState);
+
+    // Pretend that we received a message from a remote uProxy client.
     this.dispatchEvent_('onMessage', {
-      from: makeClientState(address),
+      from: clientState,
       // INSTANCE
       message: JSON.stringify(makeVersionedPeerMessage(
         3000, makeInstanceMessage(address)))

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -172,6 +172,7 @@ export class CloudSocialProvider {
   // This makes all of the stored contacts appear online.
   private loadContacts_ = () => {
     log.debug('loadContacts');
+    this.savedAddresses_ = [];
     this.storage_.get(STORAGE_KEY).then((storedString: string) => {
       if (!storedString) {
         log.debug('no saved contacts');

--- a/src/cloud/social/shim/dns.js
+++ b/src/cloud/social/shim/dns.js
@@ -1,0 +1,330 @@
+/*jshint node:true, strict:false, bitwise:false*/
+/* global freedom */
+/**
+ * Node DNS partial implementation bound to freedom['core.udpsocket'] calls.
+ *
+ * Currently only handles the methods needed by node-xmpp. Used by `net.js`.
+ * @author Will Scott (willscott@gmail.com)
+ */
+
+var DNSTypes = {
+  A: 1,
+  NS: 2,
+  MD: 3,
+  MF: 4,
+  CNAME: 5,
+  SOA: 6,
+  MB: 7,
+  MG: 8,
+  MR: 9,
+  NULL: 10,
+  WKS: 11,
+  PTR: 12,
+  HINFO: 13,
+  MINFO: 14,
+  MX: 15,
+  TXT: 16,
+  SRV: 33,
+  AXFR: 252,
+  MAILB: 253,
+  MAILA: 254,
+  ALL: 255
+};
+
+var _nid = 1;
+function nextId() {
+  return _nid++;
+}
+
+/**
+ * Create a Network Packet from a DNS Query.
+ * @param {id: short, query: domain name string, type: DNSTypes} dns
+ * @return {ArrayBuffer}
+ */
+// TODO(willscott): Support multiple queries/message.
+function flattenDNS(dns) {
+  var length = 18 + dns.query.length;
+  var buffer = new ArrayBuffer(length);
+  var byteView = new Uint8Array(buffer);
+  var dataView = new DataView(buffer);
+  dataView.setUint16(0, nextId());
+  byteView[2] = 1; // Recursion desired, other flags off.
+  byteView[3] = 0; // Response Bits.
+  dataView.setUint16(4, 1); // QDCount - # queries
+  dataView.setUint16(6, 0); // ANCount - # answers
+  dataView.setUint16(8, 0); // NSCount - # NS records
+  dataView.setUint16(10, 0); // ARCount - # Additional resources.
+
+  // QNAME
+  var labels = dns.query.split(".");
+  var offset = 12;
+  for(var i = 0; i < labels.length; i++) {
+    byteView[offset++] = labels[i].length;
+    for (var j = 0; j < labels[i].length; j++) {
+      byteView[offset++] = labels[i][j].charCodeAt(0);
+    }
+  }
+  byteView[offset++] = 0; // Root Label
+
+  // QTYPE
+  byteView[offset++] = 0;
+  byteView[offset++] = dns.type;
+
+  // QCLASS - 1 = Internet
+  byteView[offset++] = 0;
+  byteView[offset++] = 1;
+
+  return buffer;
+}
+
+/**
+ * Parse a textual label (A domain name) from a buffer.
+ * @param {DataView} buffer
+ * @param {Number} offset
+ * @param {Boolean} nofollow OPTIONAL Don't follow label pointers.
+ * @return {{text:String, length:Number}} the domain name & length of the inline label.
+ */
+function parseLabel(buffer, offset, nofollow) {
+  var data = buffer.getUint8(offset);
+  if (data === 0) {
+    return {text: "", length: 1};
+  } else if ((data & 192) === 192) { // Pointer.
+    if (nofollow) {
+      console.warn("Skipping Nested DNS label Pointer.");
+      return {text: "", length: 2};
+    } else {
+      offset = buffer.getUint16(offset) ^ (192 << 8);
+      return {text: parseLabel(buffer, offset, true).text, length: 2};
+    }
+  } else { // Length.
+    offset++;
+    var ret = "";
+    for (var i = 0; i < data; i++) {
+      ret += String.fromCharCode(buffer.getUint8(offset++));
+    }
+    var rest = parseLabel(buffer, offset, nofollow);
+    if (rest.text.length) {
+      return {text: ret + "." + rest.text, length: 1 + data + rest.length};
+    } else {
+      return {text: ret, length: 1 + data + rest.length};
+    }
+  }
+}
+
+/**
+ * Parse an SRV Record
+ * @param {ArrayBuffer} data
+ * @return {{priority:, weight:, name:, port:}}
+ */
+function _parseSRV(data) {
+  var srv = {};
+  var buf = new DataView(data);
+  srv.priority = buf.getUint16(0);
+  srv.weight = buf.getUint16(2);
+  srv.port = buf.getUint16(4);
+  srv.name = parseLabel(buf, 6, true).text;
+  return srv;
+}
+
+/**
+ * Create a JS data structure from a DNS response packet.
+ * @param {ArrayBuffer} dns
+ * @return {Object} packet structure.
+ */
+function parseDNS(dns) {
+  var dataView = new DataView(dns);
+  var ret = {};
+  ret.id = dataView.getUint16(0);
+  if ((dataView.getUint8(2) & 128) !== 128) { // is it a response
+    console.warn("Asked to parse a DNS response that is not a response");
+    return {};
+  }
+  ret.authoritative = (dataView.getUint8(2) & 4) === 4;
+  ret.truncated = (dataView.getUint8(2) & 2) === 2;
+  ret.recursed = (dataView.getUint8(2) & 1) === 1;
+  ret.canRecurse = (dataView.getUint8(3) & 128) === 128;
+  ret.code = dataView.getUint8(3) & 15;
+  var nq = dataView.getUint16(4);
+  var na = dataView.getUint16(6);
+  var ns = dataView.getUint16(8);
+  var ar = dataView.getUint16(10);
+  var label, type, qclass, q, i, offset = 12;
+  for (i = 0; i < nq; i++) {
+    // Parse Query
+    label = parseLabel(dataView, offset);
+    offset += label.length;
+    type = dataView.getUint16(offset);
+    offset += 2;
+    qclass = dataView.getUint16(offset);
+    offset += 2;
+    q = {
+      label: label.text,
+      type: type,
+      qclass: qclass
+    };
+    if (!ret.query) {
+      ret.query = [q];
+    } else {
+      ret.query.push(q);
+    }
+  }
+
+  var rdl, rclass, r, ttl, response;
+  for (i = 0; i < na; i++) {
+    // Parse Answer
+    label = parseLabel(dataView, offset);
+    offset += label.length;
+    type = dataView.getUint16(offset);
+    offset += 2;
+    rclass = dataView.getUint16(offset);
+    offset += 2;
+    ttl = dataView.getUint32(offset);
+    offset += 4;
+    rdl = dataView.getUint16(offset);
+    offset += 2;
+    response = new Uint8Array(dns, offset, rdl);
+    offset += rdl;
+    r = {
+      label: label.text,
+      type: type,
+      rclass: rclass,
+      ttl: ttl,
+      response: response
+    };
+    if (!ret.response) {
+      ret.response = [r];
+    } else {
+      ret.response.push(r);
+    }
+  }
+  // TODO(willscott): handle NS, Additional data.
+  return ret;
+}
+
+function queryDNS(server, msg, callback) {
+  var socket = freedom['core.udpsocket']();
+  socket.bind('0.0.0.0', 0).then(function() {
+    socket.once('onData', function(readInfo) {
+      callback(readInfo);
+      socket.destroy();
+    });
+    socket.sendTo(msg, server, 53).then(function(n) {
+      if (n !== msg.byteLength) {
+        console.log("Write was unsucessful.");
+        callback(null);
+        socket.destroy().then(socket.off.bind(socket));
+      }
+    });
+  });
+}
+
+// Regexp to idenitfy IPv4 addresses.
+var ipV4RegExp = /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+
+
+//TODO(willscott): Add ipv6 support.
+function isIP(ip) {
+  if (ipV4RegExp.test(ip)) {
+    return 4;
+  } else {
+    return 0;
+  }
+}
+
+var deferred = function() {
+  this.oncomplete = function() {};
+};
+
+function querySrv(name, onanswer) {
+  var ret = new deferred();
+  ret.oncomplete = onanswer;
+  var msg = flattenDNS({query: name, type: DNSTypes.SRV});
+  queryDNS('8.8.8.8', msg, function(resp) {
+    if (!resp || resp.resultCode < 0) {
+      return ret.oncomplete(-1, null);
+    }
+    var obj = parseDNS(resp.data);
+    var records = [];
+    if (obj.response) {
+      for (var i = 0; i < obj.response.length; i++) {
+        var answer = obj.response[i];
+        if (answer.type === DNSTypes.SRV) {
+          records.push(_parseSRV(answer.response.buffer));
+        }
+      }
+    }
+    onanswer(records.length > 0 ? 0 : 'ENOTFOUND', records);
+  });
+  return ret;
+}
+
+function makeAsync(callback) {
+  if (typeof callback !== 'function') {
+    return callback;
+  }
+  return function asyncCallback() {
+    if (asyncCallback.immediately) {
+      // The API already returned, we can invoke the callback immediately.
+      callback.apply(null, arguments);
+    } else {
+      var args = arguments;
+      setTimeout(function() {
+        callback.apply(null, args);
+      }, 0);
+    }
+  };
+}
+
+function errnoException(errorno, syscall) {
+  // TODO make this more compatible with ErrnoException from src/node.cc
+  // Once all of Node is using this function the ErrnoException from
+  // src/node.cc should be removed.
+  var e = new Error(syscall + ' ' + errorno);
+
+  // For backwards compatibility. libuv returns ENOENT on NXDOMAIN.
+  if (errorno === 'ENOENT') {
+    errorno = 'ENOTFOUND';
+  }
+
+  e.errno = e.code = errorno;
+  e.syscall = syscall;
+  return e;
+}
+
+// Dummy out DNS lookup to just return the hostname.  Hostname is compatible
+// with TCP Socket APIs, but IP addresses do not work properly with TLS
+// due to certificate errors.
+exports.lookup = function(hostname, family, callback) {  // parse arguments
+  if (arguments.length === 2) {
+    callback = family;
+    family = 0;
+  } else if (!family) {
+    family = 0;
+  } else {
+    family = +family;
+    if (family !== 4 && family !== 6) {
+      throw new Error('invalid argument: `family` must be 4 or 6');
+    }
+  }
+  callback = makeAsync(callback);
+  callback(null, hostname, family);
+};
+
+exports.resolveSrv = function(name, callback) {
+  function onanswer(status, result) {
+    if (!status) {
+     callback(null, result);
+    } else {
+      callback(errnoException(status, 'resolveSrv'));
+    }
+  }
+
+  callback = makeAsync(callback);
+  var wrap = querySrv(name, onanswer);
+  if (!wrap) {
+    throw errnoException('EBADARG', 'resolveSrv');
+  }
+
+  callback.immediately = true;
+  return wrap;
+};

--- a/src/cloud/social/shim/net.js
+++ b/src/cloud/social/shim/net.js
@@ -1,0 +1,1360 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var events = require('events');
+var stream = require('stream');
+var timers = require('timers');
+var util = require('util');
+var assert = require('assert');
+
+var cluster;
+var errnoException = util._errnoException;
+
+function noop() {}
+
+// constructor for lazy loading
+function createPipe() {
+  var Pipe = process.binding('pipe_wrap').Pipe;
+  return new Pipe();
+}
+
+// constructor for lazy loading
+function createTCP() {
+  var TCP = require('./tcp.js').TCP;
+  return new TCP();
+}
+
+
+function createHandle(fd) {
+  var tty = process.binding('tty_wrap');
+  var type = tty.guessHandleType(fd);
+  if (type === 'PIPE') return createPipe();
+  if (type === 'TCP') return createTCP();
+  throw new TypeError('Unsupported fd type: ' + type);
+}
+
+
+var debug = util.debuglog('net');
+
+function isPipeName(s) {
+  return util.isString(s) && toNumber(s) === false;
+}
+
+
+exports.createServer = function() {
+  return new Server(arguments[0], arguments[1]);
+};
+
+
+// Target API:
+//
+// var s = net.connect({port: 80, host: 'google.com'}, function() {
+//   ...
+// });
+//
+// There are various forms:
+//
+// connect(options, [cb])
+// connect(port, [host], [cb])
+// connect(path, [cb]);
+//
+exports.connect = exports.createConnection = function() {
+  var args = normalizeConnectArgs(arguments);
+  debug('createConnection', args);
+  var s = new Socket(args[0]);
+  return Socket.prototype.connect.apply(s, args);
+};
+
+// Returns an array [options] or [options, cb]
+// It is the same as the argument of Socket.prototype.connect().
+function normalizeConnectArgs(args) {
+  var options = {};
+
+  if (util.isObject(args[0])) {
+    // connect(options, [cb])
+    options = args[0];
+  } else if (isPipeName(args[0])) {
+    // connect(path, [cb]);
+    options.path = args[0];
+  } else {
+    // connect(port, [host], [cb])
+    options.port = args[0];
+    if (util.isString(args[1])) {
+      options.host = args[1];
+    }
+  }
+
+  var cb = args[args.length - 1];
+  return util.isFunction(cb) ? [options, cb] : [options];
+}
+exports._normalizeConnectArgs = normalizeConnectArgs;
+
+
+// called when creating new Socket, or when re-using a closed Socket
+function initSocketHandle(self) {
+  self.destroyed = false;
+  self.bytesRead = 0;
+  self._bytesDispatched = 0;
+
+  // Handle creation may be deferred to bind() or connect() time.
+  if (self._handle) {
+    self._handle.owner = self;
+    self._handle.onread = onread;
+
+    // If handle doesn't support writev - neither do we
+    if (!self._handle.writev)
+      self._writev = null;
+  }
+}
+
+function Socket(options) {
+  if (!(this instanceof Socket)) return new Socket(options);
+
+  this._connecting = false;
+  this._hadError = false;
+  this._handle = null;
+  this._host = null;
+
+  if (util.isNumber(options))
+    options = { fd: options }; // Legacy interface.
+  else if (util.isUndefined(options))
+    options = {};
+
+  stream.Duplex.call(this, options);
+
+  if (options.handle) {
+    this._handle = options.handle; // private
+  } else if (!util.isUndefined(options.fd)) {
+    this._handle = createHandle(options.fd);
+    this._handle.open(options.fd);
+    this.readable = options.readable !== false;
+    this.writable = options.writable !== false;
+  } else {
+    // these will be set once there is a connection
+    this.readable = this.writable = false;
+  }
+
+  // shut down the socket when we're finished with it.
+  this.on('finish', onSocketFinish);
+  this.on('_socketEnd', onSocketEnd);
+
+  initSocketHandle(this);
+
+  this._pendingData = null;
+  this._pendingEncoding = '';
+
+  // handle strings directly
+  this._writableState.decodeStrings = false;
+
+  // default to *not* allowing half open sockets
+  this.allowHalfOpen = options && options.allowHalfOpen || false;
+
+  // if we have a handle, then start the flow of data into the
+  // buffer.  if not, then this will happen when we connect
+  if (this._handle && options.readable !== false)
+    this.read(0);
+}
+util.inherits(Socket, stream.Duplex);
+
+Socket.prototype.secure = function(cb) {
+  this._handle.secure(cb);
+};
+
+// the user has called .end(), and all the bytes have been
+// sent out to the other side.
+// If allowHalfOpen is false, or if the readable side has
+// ended already, then destroy.
+// If allowHalfOpen is true, then we need to do a shutdown,
+// so that only the writable side will be cleaned up.
+function onSocketFinish() {
+  // If still connecting - defer handling 'finish' until 'connect' will happen
+  if (this._connecting) {
+    debug('osF: not yet connected');
+    return this.once('connect', onSocketFinish);
+  }
+
+  debug('onSocketFinish');
+  if (!this.readable || this._readableState.ended) {
+    debug('oSF: ended, destroy', this._readableState);
+    return this.destroy();
+  }
+
+  debug('oSF: not ended, call shutdown()');
+
+  // otherwise, just shutdown, or destroy() if not possible
+  if (!this._handle || !this._handle.shutdown)
+    return this.destroy();
+
+  var req = { oncomplete: afterShutdown };
+  var err = this._handle.shutdown(req);
+
+  if (err)
+    return this._destroy(errnoException(err, 'shutdown'));
+}
+
+
+function afterShutdown(status, handle, req) {
+  var self = handle.owner;
+
+  debug('afterShutdown destroyed=%j', self.destroyed,
+        self._readableState);
+
+  // callback may come after call to destroy.
+  if (self.destroyed)
+    return;
+
+  if (self._readableState.ended) {
+    debug('readableState ended, destroying');
+    self.destroy();
+  } else {
+    self.once('_socketEnd', self.destroy);
+  }
+}
+
+// the EOF has been received, and no more bytes are coming.
+// if the writable side has ended already, then clean everything
+// up.
+function onSocketEnd() {
+  // XXX Should not have to do as much crap in this function.
+  // ended should already be true, since this is called *after*
+  // the EOF errno and onread has eof'ed
+  debug('onSocketEnd', this._readableState);
+  this._readableState.ended = true;
+  if (this._readableState.endEmitted) {
+    this.readable = false;
+    maybeDestroy(this);
+  } else {
+    this.once('end', function() {
+      this.readable = false;
+      maybeDestroy(this);
+    });
+    this.read(0);
+  }
+
+  if (!this.allowHalfOpen) {
+    this.write = writeAfterFIN;
+    this.destroySoon();
+  }
+}
+
+// Provide a better error message when we call end() as a result
+// of the other side sending a FIN.  The standard 'write after end'
+// is overly vague, and makes it seem like the user's code is to blame.
+function writeAfterFIN(chunk, encoding, cb) {
+  if (util.isFunction(encoding)) {
+    cb = encoding;
+    encoding = null;
+  }
+
+  var er = new Error('This socket has been ended by the other party');
+  er.code = 'EPIPE';
+  var self = this;
+  // TODO: defer error events consistently everywhere, not just the cb
+  self.emit('error', er);
+  if (util.isFunction(cb)) {
+    process.nextTick(function() {
+      cb(er);
+    });
+  }
+}
+
+exports.Socket = Socket;
+exports.Stream = Socket; // Legacy naming.
+
+Socket.prototype.read = function(n) {
+  if (n === 0)
+    return stream.Readable.prototype.read.call(this, n);
+
+  this.read = stream.Readable.prototype.read;
+  this._consuming = true;
+  return this.read(n);
+};
+
+
+Socket.prototype.listen = function() {
+  debug('socket.listen');
+  var self = this;
+  self.on('connection', arguments[0]);
+  listen(self, null, null, null);
+};
+
+
+Socket.prototype.setTimeout = function(msecs, callback) {
+  if (msecs > 0 && !isNaN(msecs) && isFinite(msecs)) {
+    timers.enroll(this, msecs);
+    //timers._unrefActive(this);
+    if (callback) {
+      this.once('timeout', callback);
+    }
+  } else if (msecs === 0) {
+    timers.unenroll(this);
+    if (callback) {
+      this.removeListener('timeout', callback);
+    }
+  }
+};
+
+
+Socket.prototype._onTimeout = function() {
+  debug('_onTimeout');
+  this.emit('timeout');
+};
+
+
+Socket.prototype.setNoDelay = function(enable) {
+  // backwards compatibility: assume true when `enable` is omitted
+  if (this._handle && this._handle.setNoDelay)
+    this._handle.setNoDelay(util.isUndefined(enable) ? true : !!enable);
+};
+
+
+Socket.prototype.setKeepAlive = function(setting, msecs) {
+  if (this._handle && this._handle.setKeepAlive)
+    this._handle.setKeepAlive(setting, ~~(msecs / 1000));
+};
+
+
+Socket.prototype.address = function() {
+  if (this._handle && this._handle.getsockname) {
+    var out = {};
+    var err = this._handle.getsockname(out);
+    // TODO(bnoordhuis) Check err and throw?
+    return out;
+  }
+  return null;
+};
+
+
+Object.defineProperty(Socket.prototype, 'readyState', {
+  get: function() {
+    if (this._connecting) {
+      return 'opening';
+    } else if (this.readable && this.writable) {
+      return 'open';
+    } else if (this.readable && !this.writable) {
+      return 'readOnly';
+    } else if (!this.readable && this.writable) {
+      return 'writeOnly';
+    } else {
+      return 'closed';
+    }
+  }
+});
+
+
+Object.defineProperty(Socket.prototype, 'bufferSize', {
+  get: function() {
+    if (this._handle) {
+      return this._handle.writeQueueSize + this._writableState.length;
+    }
+  }
+});
+
+
+// Just call handle.readStart until we have enough in the buffer
+Socket.prototype._read = function(n) {
+  debug('_read');
+
+  if (this._connecting || !this._handle) {
+    debug('_read wait for connection');
+    this.once('connect', this._read.bind(this, n));
+  } else if (!this._handle.reading) {
+    // not already reading, start the flow
+    debug('Socket._read readStart');
+    this._handle.reading = true;
+    var err = this._handle.readStart();
+    if (err)
+      this._destroy(errnoException(err, 'read'));
+  }
+};
+
+
+Socket.prototype.end = function(data, encoding) {
+  stream.Duplex.prototype.end.call(this, data, encoding);
+  this.writable = false;
+
+  // just in case we're waiting for an EOF.
+  if (this.readable && !this._readableState.endEmitted)
+    this.read(0);
+  else
+    maybeDestroy(this);
+};
+
+
+// Call whenever we set writable=false or readable=false
+function maybeDestroy(socket) {
+  if (!socket.readable &&
+      !socket.writable &&
+      !socket.destroyed &&
+      !socket._connecting &&
+      !socket._writableState.length) {
+    socket.destroy();
+  }
+}
+
+
+Socket.prototype.destroySoon = function() {
+  if (this.writable)
+    this.end();
+
+  if (this._writableState.finished)
+    this.destroy();
+  else
+    this.once('finish', this.destroy);
+};
+
+
+Socket.prototype._destroy = function(exception, cb) {
+  debug('destroy');
+
+  var self = this;
+
+  function fireErrorCallbacks() {
+    if (cb) cb(exception);
+    if (exception && !self._errorEmitted) {
+      process.nextTick(function() {
+        self.emit('error', exception);
+      });
+      self._errorEmitted = true;
+    }
+  };
+
+  if (this.destroyed) {
+    debug('already destroyed, fire error callbacks');
+    fireErrorCallbacks();
+    return;
+  }
+
+  self._connecting = false;
+
+  this.readable = this.writable = false;
+
+  timers.unenroll(this);
+
+  debug('close');
+  if (this._handle) {
+    if (this !== process.stderr)
+      debug('close handle');
+    var isException = exception ? true : false;
+    this._handle.close(function() {
+      debug('emit close');
+      self.emit('close', isException);
+    });
+    this._handle.onread = noop;
+    this._handle = null;
+  }
+
+  // we set destroyed to true before firing error callbacks in order
+  // to make it re-entrance safe in case Socket.prototype.destroy()
+  // is called within callbacks
+  this.destroyed = true;
+  fireErrorCallbacks();
+
+  if (this.server) {
+    debug('has server');
+    this.server._connections--;
+    if (this.server._emitCloseIfDrained) {
+      this.server._emitCloseIfDrained();
+    }
+  }
+};
+
+
+Socket.prototype.destroy = function(exception) {
+  debug('destroy', exception);
+  this._destroy(exception);
+};
+
+
+// This function is called whenever the handle gets a
+// buffer, or when there's an error reading.
+function onread(nread, buffer) {
+  var handle = this;
+  var self = handle.owner;
+  assert(handle === self._handle, 'handle != self._handle');
+
+  //timers._unrefActive(self);
+
+  debug('onread', nread);
+
+  if (nread > 0) {
+    debug('got data');
+
+    // read success.
+    // In theory (and in practice) calling readStop right now
+    // will prevent this from being called again until _read() gets
+    // called again.
+
+    // if it's not enough data, we'll just call handle.readStart()
+    // again right away.
+    self.bytesRead += nread;
+
+    // Optimization: emit the original buffer with end points
+    var ret = self.push(buffer);
+
+    if (handle.reading && !ret) {
+      handle.reading = false;
+      debug('readStop');
+      var err = handle.readStop();
+      if (err)
+        self._destroy(errnoException(err, 'read'));
+    }
+    return;
+  }
+
+  // if we didn't get any bytes, that doesn't necessarily mean EOF.
+  // wait for the next one.
+  if (nread === 0) {
+    debug('not any data, keep waiting');
+    return;
+  }
+
+  // Error, possibly EOF.
+  if (nread !== -1/*uv.UV_EOF*/) {
+    return self._destroy(errnoException(nread, 'read'));
+  }
+
+  debug('EOF');
+
+  if (self._readableState.length === 0) {
+    self.readable = false;
+    maybeDestroy(self);
+  }
+
+  // push a null to signal the end of data.
+  self.push(null);
+
+  // internal end event so that we know that the actual socket
+  // is no longer readable, and we can start the shutdown
+  // procedure. No need to wait for all the data to be consumed.
+  self.emit('_socketEnd');
+}
+
+
+Socket.prototype._getpeername = function() {
+  if (!this._handle || !this._handle.getpeername) {
+    return {};
+  }
+  if (!this._peername) {
+    var out = {};
+    var err = this._handle.getpeername(out);
+    if (err) return {};  // FIXME(bnoordhuis) Throw?
+    this._peername = out;
+  }
+  return this._peername;
+};
+
+
+Socket.prototype.__defineGetter__('remoteAddress', function() {
+  return this._getpeername().address;
+});
+
+
+Socket.prototype.__defineGetter__('remotePort', function() {
+  return this._getpeername().port;
+});
+
+
+Socket.prototype._getsockname = function() {
+  if (!this._handle || !this._handle.getsockname) {
+    return {};
+  }
+  if (!this._sockname) {
+    var out = {};
+    var err = this._handle.getsockname(out);
+    if (err) return {};  // FIXME(bnoordhuis) Throw?
+    this._sockname = out;
+  }
+  return this._sockname;
+};
+
+
+Socket.prototype.__defineGetter__('localAddress', function() {
+  return this._getsockname().address;
+});
+
+
+Socket.prototype.__defineGetter__('localPort', function() {
+  return this._getsockname().port;
+});
+
+
+Socket.prototype.write = function(chunk, encoding, cb) {
+  if (!util.isString(chunk) && !util.isBuffer(chunk))
+    throw new TypeError('invalid data');
+  return stream.Duplex.prototype.write.apply(this, arguments);
+};
+
+
+Socket.prototype._writeGeneric = function(writev, data, encoding, cb) {
+  // If we are still connecting, then buffer this for later.
+  // The Writable logic will buffer up any more writes while
+  // waiting for this one to be done.
+  if (this._connecting) {
+    this._pendingData = data;
+    this._pendingEncoding = encoding;
+    this.once('connect', function() {
+      this._writeGeneric(writev, data, encoding, cb);
+    });
+    return;
+  }
+  this._pendingData = null;
+  this._pendingEncoding = '';
+
+  //timers._unrefActive(this);
+
+  if (!this._handle) {
+    this._destroy(new Error('This socket is closed.'), cb);
+    return false;
+  }
+
+  var req = { oncomplete: afterWrite, async: false };
+  var err;
+
+  if (writev) {
+    var chunks = new Array(data.length << 1);
+    for (var i = 0; i < data.length; i++) {
+      var entry = data[i];
+      var chunk = entry.chunk;
+      var enc = entry.encoding;
+      chunks[i * 2] = chunk;
+      chunks[i * 2 + 1] = enc;
+    }
+    err = this._handle.writev(req, chunks);
+
+    // Retain chunks
+    if (err === 0) req._chunks = chunks;
+  } else {
+    var enc;
+    if (util.isBuffer(data)) {
+      req.buffer = data;  // Keep reference alive.
+      enc = 'buffer';
+    } else {
+      enc = encoding;
+    }
+    err = createWriteReq(req, this._handle, data, enc);
+  }
+
+  if (err)
+    return this._destroy(errnoException(err, 'write', req.error), cb);
+
+  this._bytesDispatched += req.bytes;
+
+  // If it was entirely flushed, we can write some more right now.
+  // However, if more is left in the queue, then wait until that clears.
+  if (req.async && this._handle.writeQueueSize != 0)
+    req.cb = cb;
+  else
+    cb();
+};
+
+
+Socket.prototype._writev = function(chunks, cb) {
+  this._writeGeneric(true, chunks, '', cb);
+};
+
+
+Socket.prototype._write = function(data, encoding, cb) {
+  this._writeGeneric(false, data, encoding, cb);
+};
+
+// Important: this should have the same values as in src/stream_wrap.h
+function getEncodingId(encoding) {
+  switch (encoding) {
+    case 'buffer':
+      return 0;
+
+    case 'utf8':
+    case 'utf-8':
+      return 1;
+
+    case 'ascii':
+      return 2;
+
+    case 'ucs2':
+    case 'ucs-2':
+    case 'utf16le':
+    case 'utf-16le':
+      return 3;
+
+    default:
+      return 0;
+  }
+}
+
+function createWriteReq(req, handle, data, encoding) {
+  switch (encoding) {
+    case 'buffer':
+      return handle.writeBuffer(req, data);
+
+    case 'utf8':
+    case 'utf-8':
+      return handle.writeUtf8String(req, data);
+
+    case 'ascii':
+      return handle.writeAsciiString(req, data);
+
+    case 'ucs2':
+    case 'ucs-2':
+    case 'utf16le':
+    case 'utf-16le':
+      return handle.writeUcs2String(req, data);
+
+    default:
+      return handle.writeBuffer(req, new Buffer(data, encoding));
+  }
+}
+
+
+Socket.prototype.__defineGetter__('bytesWritten', function() {
+  var bytes = this._bytesDispatched,
+      state = this._writableState,
+      data = this._pendingData,
+      encoding = this._pendingEncoding;
+
+  state.buffer.forEach(function(el) {
+    if (util.isBuffer(el.chunk))
+      bytes += el.chunk.length;
+    else
+      bytes += Buffer.byteLength(el.chunk, el.encoding);
+  });
+
+  if (data) {
+    if (util.isBuffer(data))
+      bytes += data.length;
+    else
+      bytes += Buffer.byteLength(data, encoding);
+  }
+
+  return bytes;
+});
+
+
+function afterWrite(status, handle, req, err) {
+  var self = handle.owner;
+  if (self !== process.stderr && self !== process.stdout)
+    debug('afterWrite', status);
+
+  // callback may come after call to destroy.
+  if (self.destroyed) {
+    debug('afterWrite destroyed');
+    return;
+  }
+
+  if (status < 0) {
+    var ex = errnoException(status, 'write', err);
+    debug('write failure', ex);
+    self._destroy(ex, req.cb);
+    return;
+  }
+
+  //timers._unrefActive(self);
+
+  if (self !== process.stderr && self !== process.stdout)
+    debug('afterWrite call cb');
+
+  if (req.cb)
+    req.cb.call(self);
+}
+
+
+function connect(self, address, port, addressType, localAddress) {
+  // TODO return promise from Socket.prototype.connect which
+  // wraps _connectReq.
+
+  assert.ok(self._connecting);
+
+  var err;
+  if (localAddress) {
+    if (addressType === 6) {
+      err = self._handle.bind6(localAddress);
+    } else {
+      err = self._handle.bind(localAddress);
+    }
+
+    if (err) {
+      self._destroy(errnoException(err, 'bind'));
+      return;
+    }
+  }
+
+  var req = { oncomplete: afterConnect };
+  if (addressType === 6 || addressType === 4) {
+    port = port | 0;
+    if (port <= 0 || port > 65535)
+      throw new RangeError('Port should be > 0 and < 65536');
+
+    if (addressType === 6) {
+      err = self._handle.connect6(req, address, port);
+    } else if (addressType === 4) {
+      err = self._handle.connect(req, address, port);
+    }
+  } else {
+    err = self._handle.connect(req, address, afterConnect);
+  }
+
+  if (err) {
+    self._destroy(errnoException(err, 'connect'));
+  }
+}
+
+
+Socket.prototype.connect = function(options, cb) {
+  if (this.write !== Socket.prototype.write)
+    this.write = Socket.prototype.write;
+
+  if (!util.isObject(options)) {
+    // Old API:
+    // connect(port, [host], [cb])
+    // connect(path, [cb]);
+    var args = normalizeConnectArgs(arguments);
+    return Socket.prototype.connect.apply(this, args);
+  }
+
+  if (this.destroyed) {
+    this._readableState.reading = false;
+    this._readableState.ended = false;
+    this._readableState.endEmitted = false;
+    this._writableState.ended = false;
+    this._writableState.ending = false;
+    this._writableState.finished = false;
+    this.destroyed = false;
+    this._handle = null;
+  }
+
+  var self = this;
+  var pipe = !!options.path;
+  debug('pipe', pipe, options.path);
+
+  if (!this._handle) {
+    this._handle = pipe ? createPipe() : createTCP();
+    initSocketHandle(this);
+  }
+
+  if (util.isFunction(cb)) {
+    self.once('connect', cb);
+  }
+
+  //timers._unrefActive(this);
+
+  self._connecting = true;
+  self.writable = true;
+
+  if (pipe) {
+    connect(self, options.path);
+
+  } else if (!options.host) {
+    debug('connect: missing host');
+    self._host = '127.0.0.1';
+    connect(self, self._host, options.port, 4);
+
+  } else {
+    var host = options.host;
+    var family = options.family || 4;
+    debug('connect: find host ' + host);
+    self._host = host;
+    require('dns').lookup(host, family, function(err, ip, addressType) {
+      self.emit('lookup', err, ip, addressType);
+
+      // It's possible we were destroyed while looking this up.
+      // XXX it would be great if we could cancel the promise returned by
+      // the look up.
+      if (!self._connecting) return;
+
+      if (err) {
+        // net.createConnection() creates a net.Socket object and
+        // immediately calls net.Socket.connect() on it (that's us).
+        // There are no event listeners registered yet so defer the
+        // error event to the next tick.
+        process.nextTick(function() {
+          self.emit('error', err);
+          self._destroy();
+        });
+      } else {
+        //timers._unrefActive(self);
+
+        addressType = addressType || 4;
+
+        // node_net.cc handles null host names graciously but user land
+        // expects remoteAddress to have a meaningful value
+        ip = ip || (addressType === 4 ? '127.0.0.1' : '0:0:0:0:0:0:0:1');
+
+        connect(self, ip, options.port, addressType, options.localAddress);
+      }
+    });
+  }
+  return self;
+};
+
+
+Socket.prototype.ref = function() {
+  if (this._handle)
+    this._handle.ref();
+};
+
+
+Socket.prototype.unref = function() {
+  if (this._handle)
+    this._handle.unref();
+};
+
+
+
+function afterConnect(status, handle, req, readable, writable) {
+  var self = handle.owner;
+
+  // callback may come after call to destroy
+  if (self.destroyed) {
+    return;
+  }
+
+  assert(handle === self._handle, 'handle != self._handle');
+
+  debug('afterConnect');
+
+  assert.ok(self._connecting);
+  self._connecting = false;
+
+  if (status == 0) {
+    self.readable = readable;
+    self.writable = writable;
+    //timers._unrefActive(self);
+
+    self.emit('connect');
+
+    // start the first read, or get an immediate EOF.
+    // this doesn't actually consume any bytes, because len=0.
+    if (readable)
+      self.read(0);
+
+  } else {
+    self._connecting = false;
+    self._destroy(errnoException(status, 'connect'));
+  }
+}
+
+
+function Server(/* [ options, ] listener */) {
+  if (!(this instanceof Server)) return new Server(arguments[0], arguments[1]);
+  events.EventEmitter.call(this);
+
+  var self = this;
+
+  var options;
+
+  if (util.isFunction(arguments[0])) {
+    options = {};
+    self.on('connection', arguments[0]);
+  } else {
+    options = arguments[0] || {};
+
+    if (util.isFunction(arguments[1])) {
+      self.on('connection', arguments[1]);
+    }
+  }
+
+  this._connections = 0;
+
+  Object.defineProperty(this, 'connections', {
+    get: util.deprecate(function() {
+
+      if (self._usingSlaves) {
+        return null;
+      }
+      return self._connections;
+    }, 'connections property is deprecated. Use getConnections() method'),
+    set: util.deprecate(function(val) {
+      return (self._connections = val);
+    }, 'connections property is deprecated. Use getConnections() method'),
+    configurable: true, enumerable: true
+  });
+
+  this._handle = null;
+  this._usingSlaves = false;
+  this._slaves = [];
+
+  this.allowHalfOpen = options.allowHalfOpen || false;
+}
+util.inherits(Server, events.EventEmitter);
+exports.Server = Server;
+
+
+function toNumber(x) { return (x = Number(x)) >= 0 ? x : false; }
+
+
+var createServerHandle = exports._createServerHandle =
+    function(address, port, addressType, fd) {
+  var err = 0;
+  // assign handle in listen, and clean up if bind or listen fails
+  var handle;
+
+  if (util.isNumber(fd) && fd >= 0) {
+    try {
+      handle = createHandle(fd);
+    }
+    catch (e) {
+      // Not a fd we can listen on.  This will trigger an error.
+      debug('listen invalid fd=' + fd + ': ' + e.message);
+      return -17/*uv.UV_EINVAL*/;
+    }
+    handle.open(fd);
+    handle.readable = true;
+    handle.writable = true;
+    return handle;
+
+  } else if (port === -1 && addressType === -1) {
+    handle = createPipe();
+  } else {
+    handle = createTCP();
+  }
+
+  if (address || port) {
+    debug('bind to ' + address);
+    if (addressType === 6) {
+      err = handle.bind6(address, port);
+    } else {
+      err = handle.bind(address, port);
+    }
+  }
+
+  if (err) {
+    handle.close();
+    return err;
+  }
+
+  return handle;
+};
+
+
+Server.prototype._listen2 = function(address, port, addressType, backlog, fd) {
+  debug('listen2', address, port, addressType, backlog);
+  var self = this;
+
+  // If there is not yet a handle, we need to create one and bind.
+  // In the case of a server sent via IPC, we don't need to do this.
+  if (!self._handle) {
+    debug('_listen2: create a handle');
+    var rval = createServerHandle(address, port, addressType, fd);
+    if (util.isNumber(rval)) {
+      var error = errnoException(rval, 'listen');
+      process.nextTick(function() {
+        self.emit('error', error);
+      });
+      return;
+    }
+    self._handle = rval;
+  } else {
+    debug('_listen2: have a handle already');
+  }
+
+  self._handle.onconnection = onconnection;
+  self._handle.owner = self;
+
+  // Use a backlog of 512 entries. We pass 511 to the listen() call because
+  // the kernel does: backlogsize = roundup_pow_of_two(backlogsize + 1);
+  // which will thus give us a backlog of 512 entries.
+  var err = self._handle.listen(backlog || 511);
+
+  if (err) {
+    var ex = errnoException(err, 'listen');
+    self._handle.close();
+    self._handle = null;
+    process.nextTick(function() {
+      self.emit('error', ex);
+    });
+    return;
+  }
+
+  // generate connection key, this should be unique to the connection
+  this._connectionKey = addressType + ':' + address + ':' + port;
+
+  process.nextTick(function() {
+    self.emit('listening');
+  });
+};
+
+
+function listen(self, address, port, addressType, backlog, fd) {
+  if (!cluster) cluster = require('cluster');
+
+  if (cluster.isMaster) {
+    self._listen2(address, port, addressType, backlog, fd);
+    return;
+  }
+
+  cluster._getServer(self, address, port, addressType, fd, cb);
+
+  function cb(err, handle) {
+    // EADDRINUSE may not be reported until we call listen(). To complicate
+    // matters, a failed bind() followed by listen() will implicitly bind to
+    // a random port. Ergo, check that the socket is bound to the expected
+    // port before calling listen().
+    //
+    // FIXME(bnoordhuis) Doesn't work for pipe handles, they don't have a
+    // getsockname() method. Non-issue for now, the cluster module doesn't
+    // really support pipes anyway.
+    if (err === 0 && port > 0 && handle.getsockname) {
+      var out = {};
+      err = handle.getsockname(out);
+      if (err === 0 && port !== out.port)
+        err = -4/*uv.UV_EADDRINUSE*/;
+    }
+
+    if (err)
+      return self.emit('error', errnoException(err, 'bind'));
+
+    self._handle = handle;
+    self._listen2(address, port, addressType, backlog, fd);
+  }
+}
+
+
+Server.prototype.listen = function() {
+  var self = this;
+
+  var lastArg = arguments[arguments.length - 1];
+  if (util.isFunction(lastArg)) {
+    self.once('listening', lastArg);
+  }
+
+  var port = toNumber(arguments[0]);
+
+  // The third optional argument is the backlog size.
+  // When the ip is omitted it can be the second argument.
+  var backlog = toNumber(arguments[1]) || toNumber(arguments[2]);
+
+  var TCP = process.binding('tcp_wrap').TCP;
+
+  if (arguments.length == 0 || util.isFunction(arguments[0])) {
+    // Bind to a random port.
+    listen(self, '0.0.0.0', 0, null, backlog);
+
+  } else if (arguments[0] && util.isObject(arguments[0])) {
+    var h = arguments[0];
+    if (h._handle) {
+      h = h._handle;
+    } else if (h.handle) {
+      h = h.handle;
+    }
+    if (h instanceof TCP) {
+      self._handle = h;
+      listen(self, null, -1, -1, backlog);
+    } else if (util.isNumber(h.fd) && h.fd >= 0) {
+      listen(self, null, null, null, backlog, h.fd);
+    } else {
+      throw new Error('Invalid listen argument: ' + h);
+    }
+  } else if (isPipeName(arguments[0])) {
+    // UNIX socket or Windows pipe.
+    var pipeName = self._pipeName = arguments[0];
+    listen(self, pipeName, -1, -1, backlog);
+
+  } else if (util.isUndefined(arguments[1]) ||
+             util.isFunction(arguments[1]) ||
+             util.isNumber(arguments[1])) {
+    // The first argument is the port, no IP given.
+    listen(self, '0.0.0.0', port, 4, backlog);
+
+  } else {
+    // The first argument is the port, the second an IP.
+    require('dns').lookup(arguments[1], function(err, ip, addressType) {
+      if (err) {
+        self.emit('error', err);
+      } else {
+        listen(self, ip || '0.0.0.0', port, ip ? addressType : 4, backlog);
+      }
+    });
+  }
+  return self;
+};
+
+Server.prototype.address = function() {
+  if (this._handle && this._handle.getsockname) {
+    var out = {};
+    var err = this._handle.getsockname(out);
+    // TODO(bnoordhuis) Check err and throw?
+    return out;
+  } else if (this._pipeName) {
+    return this._pipeName;
+  } else {
+    return null;
+  }
+};
+
+function onconnection(err, clientHandle) {
+  var handle = this;
+  var self = handle.owner;
+
+  debug('onconnection');
+
+  if (err) {
+    self.emit('error', errnoException(err, 'accept'));
+    return;
+  }
+
+  if (self.maxConnections && self._connections >= self.maxConnections) {
+    clientHandle.close();
+    return;
+  }
+
+  var socket = new Socket({
+    handle: clientHandle,
+    allowHalfOpen: self.allowHalfOpen
+  });
+  socket.readable = socket.writable = true;
+
+
+  self._connections++;
+  socket.server = self;
+
+  self.emit('connection', socket);
+}
+
+
+Server.prototype.getConnections = function(cb) {
+  function end(err, connections) {
+    process.nextTick(function() {
+      cb(err, connections);
+    });
+  }
+
+  if (!this._usingSlaves) {
+    return end(null, this._connections);
+  }
+
+  // Poll slaves
+  var left = this._slaves.length,
+      total = this._connections;
+
+  function oncount(err, count) {
+    if (err) {
+      left = -1;
+      return end(err);
+    }
+
+    total += count;
+    if (--left === 0) return end(null, total);
+  }
+
+  this._slaves.forEach(function(slave) {
+    slave.getConnections(oncount);
+  });
+};
+
+
+Server.prototype.close = function(cb) {
+  function onSlaveClose() {
+    if (--left !== 0) return;
+
+    self._connections = 0;
+    self._emitCloseIfDrained();
+  }
+
+  if (!this._handle) {
+    // Throw error. Follows net_legacy behaviour.
+    throw new Error('Not running');
+  }
+
+  if (cb) {
+    this.once('close', cb);
+  }
+  this._handle.close();
+  this._handle = null;
+
+  if (this._usingSlaves) {
+    var self = this,
+        left = this._slaves.length;
+
+    // Increment connections to be sure that, even if all sockets will be closed
+    // during polling of slaves, `close` event will be emitted only once.
+    this._connections++;
+
+    // Poll slaves
+    this._slaves.forEach(function(slave) {
+      slave.close(onSlaveClose);
+    });
+  } else {
+    this._emitCloseIfDrained();
+  }
+
+  return this;
+};
+
+Server.prototype._emitCloseIfDrained = function() {
+  debug('SERVER _emitCloseIfDrained');
+  var self = this;
+
+  if (self._handle || self._connections) {
+    debug('SERVER handle? %j   connections? %d',
+          !!self._handle, self._connections);
+    return;
+  }
+
+  process.nextTick(function() {
+    debug('SERVER: emit close');
+    self.emit('close');
+  });
+};
+
+
+Server.prototype.listenFD = util.deprecate(function(fd, type) {
+  return this.listen({ fd: fd });
+}, 'listenFD is deprecated. Use listen({fd: <number>}).');
+
+Server.prototype._setupSlave = function(socketList) {
+  this._usingSlaves = true;
+  this._slaves.push(socketList);
+};
+
+Server.prototype.ref = function() {
+  if (this._handle)
+    this._handle.ref();
+};
+
+Server.prototype.unref = function() {
+  if (this._handle)
+    this._handle.unref();
+};
+
+
+// NOTE(willscott): Modified
+exports.isIPv4 = function(input) {
+  var x = /\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b/;
+  return x.test(input);
+};
+
+// IPv6 Validator courtesy of Dartware, LLC (http://intermapper.com)
+// For full details see http://intermapper.com/ipv6validator
+exports.isIPv6 = function(str) {
+  var perlipv6regex = "^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$";
+  var aeronipv6regex = "^\s*((?=.*::.*)(::)?([0-9A-F]{1,4}(:(?=[0-9A-F])|(?!\2)(?!\5)(::)|\z)){0,7}|((?=.*::.*)(::)?([0-9A-F]{1,4}(:(?=[0-9A-F])|(?!\7)(?!\10)(::))){0,5}|([0-9A-F]{1,4}:){6})((25[0-5]|(2[0-4]|1[0-9]|[1-9]?)[0-9])(\.(?=.)|\z)){4}|([0-9A-F]{1,4}:){7}[0-9A-F]{1,4})\s*$";
+
+  var regex = "/"+perlipv6regex+"/";
+  return (/^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$/.test(str));
+};
+
+
+exports.isIP = function(input) {
+  return exports.isIPv4(input) || exports.isIPv6(input);
+};
+
+
+exports._setSimultaneousAccepts = function(handle) {};

--- a/src/cloud/social/shim/tcp.js
+++ b/src/cloud/social/shim/tcp.js
@@ -1,0 +1,156 @@
+/*jshint node:true, strict:false*/
+/* global freedom */
+
+var FreedomTCP = function() {
+  this.fd = freedom['core.tcpsocket']();
+
+  // Strongly bind _onRead.
+  this._onRead = this._onRead.bind(this);
+  this.fd.on("onData", this._onRead);
+  this.fd.on('onDisconnect', function() {
+    this.onread(-1);
+  }.bind(this));
+
+  this.bufferedReads = [];
+  this.reading = true;
+};
+
+FreedomTCP.prototype._onRead = function(readInfo) {
+  var byteview = new Uint8Array(readInfo.data),
+      len = readInfo.data.byteLength,
+      buf = new Buffer(byteview);
+
+  //View read data for debugging:
+  //var str = String.fromCharCode.apply(null, byteview);
+  //console.warn('read ' + len +': ' + str);
+
+  if (this.reading) {
+    this.onread(len, buf);
+  } else {
+    this.bufferedReads.push({buf: buf, len: len});
+  }
+};
+
+FreedomTCP.prototype.close = function(cb) {
+  this.fd.off("onData", this._onRead);
+  this.fd.close().then(cb);
+  this.reading = false;
+  this.writing = false;
+};
+
+FreedomTCP.prototype.secure = function(cb) {
+  this.fd.secure()
+      .then(cb, function(e) {
+        console.error('Error securing socket: ', e);
+      });
+};
+
+FreedomTCP.prototype.ref = function() {};
+FreedomTCP.prototype.unref = function() {};
+
+FreedomTCP.prototype.readStart = function() {
+  var buffer;
+
+  this.reading = true;
+  if (this.bufferedReads) {
+    // Reading might be stopped while flushing the buffer
+    while (this.bufferedReads.length > 0 && this.reading) {
+      buffer = this.bufferedReads.shift();
+      this.onread(buffer.len, buffer.buf);
+    }
+  }
+};
+
+FreedomTCP.prototype.readStop = function() {
+  this.reading = false;
+  return false;
+};
+
+FreedomTCP.prototype.shutdown = function(cb) {
+  this.close(function(cb) {
+    cb.oncomplete();
+  }.bind({}, cb));
+};
+
+FreedomTCP.prototype._writeNative = function(req, data) {
+  req.bytes = data.byteLength;
+  var promise = this.fd.write(data);
+  promise.then(function(len) {
+    //console.log("wrote " + length + " chars to socket.");
+    req.oncomplete(len, this, req);
+  }.bind(this, data.byteLength));
+};
+
+FreedomTCP.prototype.writeBuffer = function(req, buf) {
+  var data = buf.toArrayBuffer();
+  this._writeNative(req, data);
+};
+
+FreedomTCP.prototype.writeAsciiString = function(req, s) {
+  var data = new Uint8Array(s.length), i = 0;
+  for (; i < s.length; i += 1) {
+    data[i] = s.charCodeAt(i);
+  }
+  this._writeNative(req, data);
+};
+
+FreedomTCP.prototype.writeUtf8String = function(req, s) {
+  //View write data for debugging:
+  //console.warn('wrote ' + s.length + ': ' + s);
+
+  var write = function() {
+    var data = new Uint8Array(s.length), i = 0;
+    for (; i < s.length; i += 1) {
+      data[i] = s.charCodeAt(i);
+    }
+    this._writeNative(req, data);
+  }.bind(this);
+
+  if (s === '<starttls xmlns="urn:ietf:params:xml:ns:xmpp-tls"/>') {
+    // This is a hack to work around issues with secure sockets in Chrome:
+    // https://code.google.com/p/chromium/issues/detail?id=403076
+    // This will be a no-op in browsers other than Chrome, and should be
+    // removed when that issue is fixed.
+    // See details at https://github.com/uProxy/uproxy/issues/413
+    this.fd.prepareSecure().then(function() {
+      write();  // Always write regardless of prepare secure callback
+    });
+  } else {
+    write();
+  }
+};
+
+FreedomTCP.prototype.writeUcs2String = function(req, s) {
+  var data = new Uint8Array(s.length), i = 0;
+  for (; i < s.length; i += 1) {
+    data[i] = s.charCodeAt(i);
+  }
+  this._writeNative(req, data);
+};
+
+//TODO: support writing multiple chunks together
+//FreedomTCP.prototype.writev
+
+//TODO: Support server open/bind/listen.
+//FreedomTCP.prototype.open
+//FreedomTCP.prototype.bind
+//FreedomTCP.prototype.listen
+
+FreedomTCP.prototype.connect = function(cb, address, port) {
+  var self = this;
+  this.fd.connect(address, port).then(function(status) {
+    cb.oncomplete(0, self, cb, true, true);
+  }.bind(this));
+};
+
+FreedomTCP.prototype.bind6 = FreedomTCP.prototype.bind;
+FreedomTCP.prototype.connect6 = FreedomTCP.prototype.connect;
+
+//TODO: implement getsockname / getpeername.
+//FreedomTCP.prototype.getsockname
+//FreedomTCP.prototype.getpeername
+//FreedomTCP.prototype.setNoDelay
+//FreedomTCP.prototype.setKeepAlive
+
+
+exports.TCP = FreedomTCP;

--- a/third_party/tsd.json
+++ b/third_party/tsd.json
@@ -31,6 +31,9 @@
     },
     "freedom/freedom-module-env.d.ts": {
       "commit": "af76bf46025371c760d8fe8c03cf874428da6124"
+    },
+    "ssh2/ssh2.d.ts": {
+      "commit": "14ab703f435375194360cdba3abab61afc879c18"
     }
   }
 }


### PR DESCRIPTION
First cut of a social provider which enables proxying with Zork instances. It's a social2 provider in which each instance is exposed as a friend in the contact list, and instances can be added via the invite flow.

An SSH tunnel is established with the server, across which signalling messages are exchanged. Currently, the server is expected to have a `giver` account having a password `giver`. This will change to key-based authentication, with the keys emailed to users.

Lots of polish to come.

In-progress uProxy pull request:
https://github.com/uProxy/uproxy/compare/trevj-social-cloud

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/310)

<!-- Reviewable:end -->
