### PR TITLE
fix browserify issue on old versions of node

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "jasmine-core": "^2.3.4",
     "request": "^2.53.0",
     "socks5-http-client": "^0.1.6",
-    "ssh2": "^0.4.11",
+    "ssh2": "0.4.12",
+    "ssh2-streams": "0.0.18",
     "tsd": "^0.6.5",
     "typescript": "^1.6.2",
     "yargs": "^3.0.4"


### PR DESCRIPTION
Weird. Works fine on node 5, not otherwise. This works on both.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/312)
<!-- Reviewable:end -->
