### PR TITLE
fix for ssh on firefox

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -559,6 +559,8 @@ module.exports = (grunt) ->
           # Subset of ssh2-streams (all except SFTP) which works well in
           # the browser.
           './src/cloud/social/alias/ssh2-streams.js:ssh2-streams'
+          # Fallback for crypto-browserify's randombytes, for Firefox.
+          './src/cloud/social/alias/randombytes.js:randombytes'
         ]
       })
       simpleChatFreedomModule: Rule.browserify 'simple-chat/freedom-module'

--- a/src/cloud/social/alias/randombytes.js
+++ b/src/cloud/social/alias/randombytes.js
@@ -1,0 +1,29 @@
+// Alternative to crypto-browserify's randombytes shim which
+// falls back to Math.random when crypto.getRandomValues is
+// unavailable, which is currently the case in Firefox web workers.
+// TODO: Fallback to something better such as freedomjs' core.crypto
+//       module (difficult because it is an asynchronous API).
+
+// Firefox raises an error if we so much as even try
+// to *access* crypto, hence this bizarre construction.
+var cryptoAvailable = true;
+try {
+  if (crypto) {}
+} catch(e) {
+  console.warn('crypto unavailable, falling back to Math.random');
+  cryptoAvailable = false;
+}
+
+module.exports = function(size) {
+  var buffer = new Buffer(size);
+  if (cryptoAvailable) {
+    // Although this looks weird, it's how crypto-browserify does it too:
+    //   https://github.com/crypto-browserify/randombytes/blob/master/browser.js
+    crypto.getRandomValues(buffer);
+  } else {
+    for (var i = 0; i < size; i++) {
+      buffer[i] = Math.floor(Math.random() * 256);
+    }
+  }
+  return buffer;
+}


### PR DESCRIPTION
While `Math.random` is not a good long-term solution, I couldn't find any other _synchronous_ solution.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/328)

<!-- Reviewable:end -->
