### PR TITLE
better error handling and logging for cloud

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -125,6 +125,7 @@ taskManager.add 'browserifySpecs', [
   'browserify:datachannelSpec'
   'browserify:poolSpec'
   'browserify:tcpSpec'
+  'browserify:linefeederSpec'
   'browserify:queueSpec'
   'browserify:turnFrontEndMessagesSpec'
   'browserify:turnFrontEndSpec'
@@ -589,6 +590,7 @@ module.exports = (grunt) ->
       churnCovSpec: Rule.addCoverageToBrowserify(Rule.browserifySpec 'churn/churn')
       handlerSpec: Rule.browserifySpec 'handler/queue'
       handlerCovSpec: Rule.addCoverageToBrowserify(Rule.browserifySpec 'handler/queue')
+      linefeederSpec: Rule.browserifySpec 'net/linefeeder'
       loggingProviderSpec: Rule.browserifySpec 'loggingprovider/loggingprovider'
       loggingProviderCovSpec: Rule.addCoverageToBrowserify(Rule.browserifySpec 'loggingprovider/loggingprovider')
       loggingSpec: Rule.browserifySpec 'logging/logging'

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -4,7 +4,9 @@
 /// <reference path='../../../../third_party/typings/ssh2/ssh2.d.ts' />
 
 import arraybuffers = require('../../arraybuffers/arraybuffers');
+import linefeeder = require('../../net/linefeeder');
 import logging = require('../../logging/logging');
+import queue = require('../../handler/queue');
 
 // https://github.com/borisyankov/DefinitelyTyped/blob/master/ssh2/ssh2-tests.ts
 import * as ssh2 from 'ssh2';
@@ -430,44 +432,38 @@ class Connection {
 
             this.stream_ = stream;
 
-            // TODO: add error handler for stream
-            let leftover = new ArrayBuffer(0);
-            this.stream_.on('data', (data: Buffer) => {
-              leftover = arraybuffers.concat([leftover,
-                  arraybuffers.bufferToArrayBuffer(data)]);
-              let i = arraybuffers.indexOf(leftover, Connection.COMMAND_DELIMITER);
-              while (i !== -1) {
-                let parts = arraybuffers.split(leftover, i);
-                let reply = arraybuffers.arrayBufferToString(parts[0]).trim();
-                log.debug('%1: received message: %2', this.name_, reply);
-                leftover = parts[1].slice(1);
-                i = arraybuffers.indexOf(leftover, Connection.COMMAND_DELIMITER);
-
-                switch (this.state_) {
-                  case ConnectionState.WAITING_FOR_PING:
-                    if (reply === 'ping') {
-                      this.setState_(ConnectionState.ESTABLISHED);
-                      F();
-                    } else {
-                      this.close();
-                      R(new Error('did not receive ping from server on login: ' +
-                          reply));
-                    }
-                    break;
-                  case ConnectionState.ESTABLISHED:
-                    try {
-                      this.received_(JSON.parse(reply));
-                    } catch (e) {
-                      log.warn('%1: could not de-serialise signalling message: %2',
-                          this.invite_, reply);
-                    }
-                    break;
-                  default:
-                    log.warn('%1: did not expect message in state %2: %3',
-                        this.name_, ConnectionState[this.state_], reply);
+            var bufferQueue = new queue.Queue<ArrayBuffer, void>();
+            new linefeeder.LineFeeder(bufferQueue).setSyncHandler((reply: string) => {
+              log.debug('%1: received message: %2', this.name_, reply);
+              switch (this.state_) {
+                case ConnectionState.WAITING_FOR_PING:
+                  if (reply === 'ping') {
+                    this.setState_(ConnectionState.ESTABLISHED);
+                    F();
+                  } else {
                     this.close();
-                }
+                    R(new Error('did not receive ping from server on login: ' +
+                      reply));
+                  }
+                  break;
+                case ConnectionState.ESTABLISHED:
+                  try {
+                    this.received_(JSON.parse(reply));
+                  } catch (e) {
+                    log.warn('%1: could not de-serialise signalling message: %2',
+                      this.invite_, reply);
+                  }
+                  break;
+                default:
+                  log.warn('%1: did not expect message in state %2: %3',
+                    this.name_, ConnectionState[this.state_], reply);
+                  this.close();
               }
+            });
+
+            // TODO: add error handler for stream
+            stream.on('data', (buffer: Buffer) => {
+              bufferQueue.handle(arraybuffers.bufferToArrayBuffer(buffer));
             }).on('error', (e: Error) => {
               // This occurs when:
               //  - host cannot be reached, e.g. non-existant hostname

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -426,7 +426,8 @@ class Connection {
           ZORK_HOST, ZORK_PORT, (e: Error, stream: ssh2.Channel) => {
             if (e) {
               this.close();
-              R('error establishing tunnel: ' + e.toString());
+              R(new Error('error establishing tunnel: ' + e.toString()));
+              return;
             }
             this.setState_(ConnectionState.WAITING_FOR_PING);
 

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -280,7 +280,7 @@ export class CloudSocialProvider {
           //       the instance (safe because all we've done is run ping).
           log.info('new proxying session %1', payload.proxyingId);
           if (!(destinationClientId in this.savedContacts_)) {
-            return Promise.reject('unknown client ' + destinationClientId);
+            return Promise.reject(new Error('unknown client ' + destinationClientId));
           }
           return this.reconnect_(this.savedContacts_[destinationClientId].invite).then(
               (connection: Connection) => {
@@ -293,14 +293,14 @@ export class CloudSocialProvider {
               connection.sendMessage(JSON.stringify(payload));
             });
           } else {
-            return Promise.reject('unknown client ' + destinationClientId);
+            return Promise.reject(new Error('unknown client ' + destinationClientId));
           }
         }
       } else {
-        return Promise.reject('message has no or wrong type field');
+        return Promise.reject(new Error('message has no or wrong type field'));
       }
     } catch (e) {
-      return Promise.reject('could not de-serialise message: ' + e.message);
+      return Promise.reject(new Error('could not de-serialise message: ' + e.message));
     }
   }
 
@@ -349,7 +349,7 @@ export class CloudSocialProvider {
         // Return nothing for type checking purposes.
       });
     } catch (e) {
-      return Promise.reject('could not parse invite code: ' + e.message);
+      return Promise.reject(new Error('could not parse invite code: ' + e.message));
     }
   }
 
@@ -395,7 +395,7 @@ class Connection {
   // TODO: timeout
   public connect = (): Promise<void> => {
     if (this.state_ !== ConnectionState.NEW) {
-      return Promise.reject('can only connect in NEW state');
+      return Promise.reject(new Error('can only connect in NEW state'));
     }
     this.state_ = ConnectionState.CONNECTING;
 
@@ -529,7 +529,7 @@ class Connection {
   // Fetches the server's description, i.e. /banner.
   public getBanner = (): Promise<string> => {
     if (this.state_ !== ConnectionState.ESTABLISHED) {
-      return Promise.reject('can only fetch banner in ESTABLISHED state');
+      return Promise.reject(new Error('can only fetch banner in ESTABLISHED state'));
     }
     return new Promise<string>((F, R) => {
       this.client_.exec('cat /banner', (e: Error, stream: ssh2.Channel) => {

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -439,6 +439,7 @@ class Connection {
               while (i !== -1) {
                 let parts = arraybuffers.split(leftover, i);
                 let reply = arraybuffers.arrayBufferToString(parts[0]).trim();
+                log.debug('%1: received message: %2', this.name_, reply);
                 leftover = parts[1].slice(1);
                 i = arraybuffers.indexOf(leftover, Connection.COMMAND_DELIMITER);
 

--- a/src/net/linefeeder.spec.ts
+++ b/src/net/linefeeder.spec.ts
@@ -1,0 +1,48 @@
+/// <reference path='../../../third_party/typings/jasmine/jasmine.d.ts' />
+
+import arraybuffers = require('../arraybuffers/arraybuffers');
+import linefeeder = require('./linefeeder');
+import queue = require('../handler/queue');
+
+describe('LineFeeder', function() {
+  var bufferQueue: queue.Queue<ArrayBuffer, void>;
+  var lines: linefeeder.LineFeeder;
+
+  beforeEach(() => {
+    bufferQueue = new queue.Queue<ArrayBuffer, void>();
+    lines = new linefeeder.LineFeeder(bufferQueue);
+  });
+
+  it('one and done', (done) => {
+    var s = 'hello world';
+    bufferQueue.handle(arraybuffers.stringToArrayBuffer(s + '\n'));
+
+    lines.setSyncNextHandler((result: string) => {
+      expect(result).toEqual(s);
+      done();
+    });
+  });
+
+  it('dangling lines', (done) => {
+    var s = 'hello world';
+    bufferQueue.handle(arraybuffers.stringToArrayBuffer('hello '));
+    bufferQueue.handle(arraybuffers.stringToArrayBuffer('world\n'));
+
+    lines.setSyncNextHandler((result: string) => {
+      expect(result).toEqual(s);
+      done();
+    });
+  });
+
+  it('multiple lines in one buffer', (done) => {
+    bufferQueue.handle(arraybuffers.stringToArrayBuffer('a\nb\n'));
+
+    lines.setSyncNextHandler((result: string) => {
+      expect(result).toEqual('a');
+      lines.setSyncNextHandler((result: string) => {
+        expect(result).toEqual('b');
+        done();
+      });
+    });
+  });
+});

--- a/src/net/linefeeder.ts
+++ b/src/net/linefeeder.ts
@@ -1,0 +1,27 @@
+/// <reference path='../../../third_party/typings/es6-promise/es6-promise.d.ts' />
+
+import arraybuffers = require('../arraybuffers/arraybuffers');
+import queue = require('../handler/queue');
+
+// Transforms a raw network-like ArrayBuffer-based queue into
+// a telnet-style string-based queue.
+export class LineFeeder extends queue.Queue<string, void> {
+  private static DELIMITER = arraybuffers.decodeByte(
+      arraybuffers.stringToArrayBuffer('\n'));
+
+  constructor(source: queue.Queue<ArrayBuffer, void>) {
+    super();
+    let leftover = new ArrayBuffer(0);
+    source.setSyncHandler((buffer: ArrayBuffer) => {
+      leftover = arraybuffers.concat([leftover, buffer]);
+      let i = arraybuffers.indexOf(leftover, LineFeeder.DELIMITER);
+      while (i !== -1) {
+        let parts = arraybuffers.split(leftover, i);
+        let line = arraybuffers.arrayBufferToString(parts[0]);
+        leftover = parts[1].slice(1);
+        i = arraybuffers.indexOf(leftover, LineFeeder.DELIMITER);
+        this.handle(line);
+      }
+    });
+  }
+}

--- a/src/zork/freedom-module.ts
+++ b/src/zork/freedom-module.ts
@@ -76,7 +76,7 @@ function serveConnection(connection: tcp.Connection): void {
   var transformerConfig: string;
 
   const lineFeeder = new linefeeder.LineFeeder(connection.dataFromSocketQueue);
-  var doit = (command: string) => {
+  var processCommand = (command: string) => {
     log.debug('%1: received command: %2', connection.connectionId, command);
 
     let keepParsing = false;
@@ -140,10 +140,10 @@ function serveConnection(connection: tcp.Connection): void {
     }
 
     if (keepParsing) {
-      lineFeeder.setSyncNextHandler(doit);
+      lineFeeder.setSyncNextHandler(processCommand);
     }
   };
-  lineFeeder.setSyncNextHandler(doit);
+  lineFeeder.setSyncNextHandler(processCommand);
 
   connection.onceClosed.then((kind:tcp.SocketCloseKind) => {
     log.info('%1: closed (%2)',

--- a/src/zork/freedom-module.ts
+++ b/src/zork/freedom-module.ts
@@ -167,7 +167,7 @@ function get(
 
   socksToRtc.start(new tcp.Server(socksEndpoint), bridge.best('sockstortc',
       pcConfig, undefined, transformerConfig)).then((endpoint:net.Endpoint) => {
-    log.info('%1: SOCKS server listening on %2 (curl -x socks5h://%1:%2 www.example.com)',
+    log.info('%1: SOCKS server listening on %2 (curl -x socks5h://%3:%4 www.example.com)',
         connection.connectionId, endpoint,endpoint.address, endpoint.port);
     connection.close();
   }, (e:Error) => {

--- a/src/zork/freedom-module.ts
+++ b/src/zork/freedom-module.ts
@@ -144,6 +144,11 @@ function serveConnection(connection: tcp.Connection): void {
     }
   };
   lineFeeder.setSyncNextHandler(doit);
+
+  connection.onceClosed.then((kind:tcp.SocketCloseKind) => {
+    log.info('%1: closed (%2)',
+      connection.connectionId, tcp.SocketCloseKind[kind]);
+  });
 }
 
 // Creates a SocksToRtc instance and forwards signals between it and the


### PR DESCRIPTION
A bunch of stuff which, from tesing on my workstation and laptop, seems to significantly help the connection rate:
- factor out a class, `LineFeeder`, to convert an `ArrayBuffer` queue -> strings, delimiting on newlines (this was a real mess...#1 fix here)
- moar zork logging!
- always reject promises with an `Error`
- return after rejecting, when necessary

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/332)

<!-- Reviewable:end -->
