### PR TITLE
Update the address of the NAT probe server

### DIFF
--- a/src/nat/probe.ts
+++ b/src/nat/probe.ts
@@ -8,7 +8,7 @@ import logging = require('../logging/logging');
 // We keep this running on Amazon EC2 and the source
 // may be found here:
 //   https://github.com/uProxy/uproxy-probe/blob/master/python-src/probe-server.py
-var TEST_SERVER = '54.68.73.184';
+var TEST_SERVER = '52.34.126.245';
 var TEST_PORT = 6666;
 
 var log :logging.Log = new logging.Log('probe');


### PR DESCRIPTION
IP address is now an EC2 elastic IP so we should be able to move it even
if we have to shut down the server.

Fixes uproxy/uproxy#2157

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/345)
<!-- Reviewable:end -->
