### PR TITLE
add CloudInstaller, to install uProxy on a server via SSH

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -65,12 +65,12 @@ config =
     libsForDeployerChromeApp:
       Rule.copyLibs
         npmLibNames: ['freedom-for-chrome', 'forge-min']
-        pathsFromDevBuild: ['loggingprovider', 'cloud/deployer', 'cloud/digitalocean']
+        pathsFromDevBuild: ['loggingprovider', 'cloud/deployer', 'cloud/digitalocean', 'cloud/install']
         localDestPath: 'samples/deployer-chromeapp/'
     libsForDeployerFirefoxApp:
       Rule.copyLibs
         npmLibNames: ['freedom-for-firefox', 'forge-min']
-        pathsFromDevBuild: ['loggingprovider', 'cloud/deployer', 'cloud/digitalocean']
+        pathsFromDevBuild: ['loggingprovider', 'cloud/deployer', 'cloud/digitalocean', 'cloud/install']
         localDestPath: 'samples/deployer-firefoxapp/data'
 
     libsForZorkChromeApp:
@@ -299,11 +299,20 @@ config =
           ignore: ['ws', 'path']
           browserifyOptions: { standalone: 'browserified_exports' }
         })
-    digitalOceanFreedomModule: Rule.browserify 'cloud/digitalocean/freedom-module'
-    # Sample app freedom modules.
-    copypasteChatFreedomModule: Rule.browserify 'copypaste-chat/freedom-module'
-    copypasteSocksFreedomModule: Rule.browserify 'copypaste-socks/freedom-module'
-    echoServerFreedomModule: Rule.browserify 'echo/freedom-module'
+    # TODO: Make the browserified SSH stuff re-useable, e.g. freedomjs module.
+    cloudInstallerFreedomModule: Rule.browserify('cloud/install/freedom-module', {
+      alias : [
+        # Shims for node's dns and net modules from freedom-social-xmpp,
+        # with a couple of fixes.
+        './src/cloud/social/shim/net.js:net'
+        './src/cloud/social/shim/dns.js:dns'
+        # Subset of ssh2-streams (all except SFTP) which works well in
+        # the browser.
+        './src/cloud/social/alias/ssh2-streams.js:ssh2-streams'
+        # Fallback for crypto-browserify's randombytes, for Firefox.
+        './src/cloud/social/alias/randombytes.js:randombytes'
+      ]
+    })
     cloudSocialProviderFreedomModule: Rule.browserify('cloud/social/freedom-module', {
       alias : [
         # Shims for node's dns and net modules from freedom-social-xmpp,
@@ -317,7 +326,12 @@ config =
         './src/cloud/social/alias/randombytes.js:randombytes'
       ]
     })
+    digitalOceanFreedomModule: Rule.browserify 'cloud/digitalocean/freedom-module'
+    # Sample app freedom modules.
+    copypasteChatFreedomModule: Rule.browserify 'copypaste-chat/freedom-module'
+    copypasteSocksFreedomModule: Rule.browserify 'copypaste-socks/freedom-module'
     deployerFreedomModule: Rule.browserify 'cloud/deployer/freedom-module'
+    echoServerFreedomModule: Rule.browserify 'echo/freedom-module'
     simpleChatFreedomModule: Rule.browserify 'simple-chat/freedom-module'
     simpleSocksFreedomModule: Rule.browserify 'simple-socks/freedom-module'
     simpleTurnFreedomModule: Rule.browserify 'simple-turn/freedom-module'
@@ -432,6 +446,7 @@ taskManager.add 'base', [
   'ts:srcInCoreEnv'
   'browserify:loggingProvider'
   'browserify:churnPipeFreedomModule'
+  'browserify:cloudInstallerFreedomModule'
   'browserify:cloudSocialProviderFreedomModule'
   'browserify:digitalOceanFreedomModule'
 ]

--- a/src/cloud/deployer/freedom-module.json
+++ b/src/cloud/deployer/freedom-module.json
@@ -18,6 +18,10 @@
     "digitalocean": {
       "url": "../digitalocean/freedom-module.json",
       "api": "digitalocean"
+    },
+    "cloudinstall": {
+      "url": "../install/freedom-module.json",
+      "api": "cloudinstall"
     }
   }
 }

--- a/src/cloud/digitalocean/provisioner.ts
+++ b/src/cloud/digitalocean/provisioner.ts
@@ -256,6 +256,10 @@ class Provisioner {
    * Waits for all in-progress Digital Ocean actions to complete
    * e.g. after powering on a machine, or creating a VM
    */
+  // TODO: It's not until several moments after this resolves
+  //       that you can actually SSH into the server. We need
+  //       to find a way to detect when the machine is *really*
+  //       ready.
   private waitDigitalOceanActions_ = () : Promise<void> => {
     console.log("Polling for Digital Ocean in-progress actions");
     return this.doRequest_("GET", "droplets/" + this.state_.cloud.vm.id + "/actions").then((resp: any) => {

--- a/src/cloud/digitalocean/provisioner.ts
+++ b/src/cloud/digitalocean/provisioner.ts
@@ -326,7 +326,12 @@ class Provisioner {
           name: name,
           region: region,
           size: "512mb",
-          image: "ubuntu-14-04-x64",
+          // 'docker' is a slug name, a.k.a. application image, a.k.a. one-click app.
+          // The full list of available slugs is available only through the API, e.g.:
+          //   this.doRequest_("GET", "images?type=application&per_page=50").then((resp: any) => {
+          //     console.log('available application images: ' + JSON.stringify(resp, undefined, 2));
+          // });
+          image: 'docker',
           ssh_keys: [ this.state_.cloud.ssh.id ]
         }));
         // If missing, create the droplet

--- a/src/cloud/install/freedom-module.json
+++ b/src/cloud/install/freedom-module.json
@@ -1,0 +1,26 @@
+{
+  "name": "Cloud Installer",
+  "description": "Installs uProxy in the cloud, via SSH.",
+  "app": {
+    "script": [
+      "freedom-module.static.js"
+    ]
+  },
+  "provides": [ "cloudinstall" ],
+  "default": "cloudinstall",
+  "api": {
+    "cloudinstall": {
+      "install": {
+        "type": "method",
+        "value": ["string", "number", "string", "string"],
+        "ret": "string"
+      },
+      "err": {
+        "message": "string"
+      }
+    }
+  },
+  "permissions": [
+    "core.tcpsocket"
+  ]
+}

--- a/src/cloud/install/freedom-module.ts
+++ b/src/cloud/install/freedom-module.ts
@@ -1,0 +1,7 @@
+/// <reference path='../../../../third_party/typings/freedom/freedom-module-env.d.ts' />
+
+import CloudInstaller = require('./installer');
+
+freedom().providePromises(CloudInstaller);
+
+export = CloudInstaller

--- a/src/cloud/install/installer.ts
+++ b/src/cloud/install/installer.ts
@@ -54,8 +54,6 @@ class CloudInstaller {
             return;
           }
           stream.on('end', () => {
-            log.debug('exec stream closed');
-            // TODO: is it correct to reject if we haven't already resolved?
             R({
               message: 'invitation URL not found'
             });
@@ -73,14 +71,13 @@ class CloudInstaller {
         // This occurs when:
         //  - user supplies the wrong username or password
         //  - host cannot be reached, e.g. non-existant hostname
-        log.warn('failed to connect: %1', e);
         R({
           message: 'could not login: ' + e.message
         });
       }).on('end', () => {
         log.debug('end');
       }).on('close', (hadError: boolean) => {
-        log.debug('close');
+        log.debug('close (hadError: %1)', hadError);
       }).connect(connectConfig);
     });
   }

--- a/src/cloud/install/installer.ts
+++ b/src/cloud/install/installer.ts
@@ -12,8 +12,7 @@ var Client = require('ssh2').Client;
 var log: logging.Log = new logging.Log('cloud installer');
 
 // Command to install uProxy.
-// TODO: update the URL once the uproxy-docker pull request is submitted
-const INSTALL_COMMAND = 'curl -sSL https://raw.githubusercontent.com/uProxy/uproxy-docker/trevj-curl-installer/install-cloud.sh | sh';
+const INSTALL_COMMAND = 'curl -sSL https://raw.githubusercontent.com/uProxy/uproxy-docker/master/install-cloud.sh | sh';
 
 // Prefix for invitation URLs.
 const INVITATION_URL_PREFIX = 'https://www.uproxy.org/invite/';

--- a/src/cloud/install/installer.ts
+++ b/src/cloud/install/installer.ts
@@ -15,8 +15,8 @@ var log: logging.Log = new logging.Log('cloud installer');
 // TODO: update the URL once the uproxy-docker pull request is submitted
 const INSTALL_COMMAND = 'curl -sSL https://raw.githubusercontent.com/uProxy/uproxy-docker/trevj-curl-installer/install-cloud.sh | sh';
 
-// Prefix for the output line containing the invitation code.
-const INVITATION_LINE_PREFIX = 'invite code: ';
+// Prefix for invitation URLs.
+const INVITATION_URL_PREFIX = 'https://www.uproxy.org/invite/';
 
 // Installs uProxy on a server, via SSH.
 // The process is as close as possible to a manual install
@@ -62,8 +62,8 @@ class CloudInstaller {
           }).on('data', function(data: Buffer) {
             const output = data.toString();
             log.debug('STDOUT: %1', output);
-            if (output.indexOf(INVITATION_LINE_PREFIX) === 0) {
-              F(output.substring(INVITATION_LINE_PREFIX.length));
+            if (output.indexOf(INVITATION_URL_PREFIX) === 0) {
+              F(output.substring(INVITATION_URL_PREFIX.length));
             }
           }).stderr.on('data', function(data: Buffer) {
             log.error(data.toString());

--- a/src/cloud/install/installer.ts
+++ b/src/cloud/install/installer.ts
@@ -1,0 +1,89 @@
+/// <reference path='../../../../third_party/typings/es6-promise/es6-promise.d.ts' />
+/// <reference path='../../../../third_party/typings/freedom/freedom-module-env.d.ts' />
+/// <reference path='../../../../third_party/typings/node/node.d.ts' />
+/// <reference path='../../../../third_party/typings/ssh2/ssh2.d.ts' />
+
+import logging = require('../../logging/logging');
+
+// https://github.com/borisyankov/DefinitelyTyped/blob/master/ssh2/ssh2-tests.ts
+import * as ssh2 from 'ssh2';
+var Client = require('ssh2').Client;
+
+var log: logging.Log = new logging.Log('cloud installer');
+
+// Command to install uProxy.
+// TODO: update the URL once the uproxy-docker pull request is submitted
+const INSTALL_COMMAND = 'curl -sSL https://raw.githubusercontent.com/uProxy/uproxy-docker/trevj-curl-installer/install-cloud.sh | sh';
+
+// Prefix for the output line containing the invitation code.
+const INVITATION_LINE_PREFIX = 'invite code: ';
+
+// Installs uProxy on a server, via SSH.
+// The process is as close as possible to a manual install
+// so that we have fewer paths to test.
+class CloudInstaller {
+  constructor(private dispatchEvent_: (name: string, args: Object) => void) {}
+
+  // Runs the install command via SSH, resolving with the invitation URL.
+  public install = (
+      host:string,
+      port:number,
+      username:string,
+      key:string) : Promise<string> => {
+    log.debug('installing uproxy on %1:%2 as %3', host, port, username);
+
+    const connectConfig: ssh2.ConnectConfig = {
+      host: host,
+      port: port,
+      username: username,
+      privateKey: key,
+      // Remaining fields only for type-correctness.
+      tryKeyboard: false,
+      debug: undefined
+    };
+
+    const client = new Client();
+    return new Promise<string>((F, R) => {
+      client.on('ready', () => {
+        log.debug('logged into server');
+        client.exec(INSTALL_COMMAND, (e: Error, stream: ssh2.Channel) => {
+          if (e) {
+            R({
+              message: 'could not execute command: ' + e.message
+            });
+            return;
+          }
+          stream.on('end', () => {
+            log.debug('exec stream closed');
+            // TODO: is it correct to reject if we haven't already resolved?
+            R({
+              message: 'invitation URL not found'
+            });
+          }).on('data', function(data: Buffer) {
+            const output = data.toString();
+            log.debug('STDOUT: %1', output);
+            if (output.indexOf(INVITATION_LINE_PREFIX) === 0) {
+              F(output.substring(INVITATION_LINE_PREFIX.length));
+            }
+          }).stderr.on('data', function(data: Buffer) {
+            log.error(data.toString());
+          });
+        });
+      }).on('error', (e: Error) => {
+        // This occurs when:
+        //  - user supplies the wrong username or password
+        //  - host cannot be reached, e.g. non-existant hostname
+        log.warn('failed to connect: %1', e);
+        R({
+          message: 'could not login: ' + e.message
+        });
+      }).on('end', () => {
+        log.debug('end');
+      }).on('close', (hadError: boolean) => {
+        log.debug('close');
+      }).connect(connectConfig);
+    });
+  }
+}
+
+export = CloudInstaller;

--- a/src/cloud/install/installer.ts
+++ b/src/cloud/install/installer.ts
@@ -61,6 +61,9 @@ class CloudInstaller {
           }).on('data', function(data: Buffer) {
             const output = data.toString();
             log.debug('STDOUT: %1', output);
+            // Search for the URL anywhere in the line so we will
+            // continue to work in the face of minor changes
+            // to the install script.
             if (output.indexOf(INVITATION_URL_PREFIX) === 0) {
               F(output.substring(INVITATION_URL_PREFIX.length));
             }

--- a/src/cloud/install/installer.ts
+++ b/src/cloud/install/installer.ts
@@ -41,18 +41,20 @@ class CloudInstaller {
       debug: undefined
     };
 
-    const client = new Client();
+    const connection = new Client();
     return new Promise<string>((F, R) => {
-      client.on('ready', () => {
+      connection.on('ready', () => {
         log.debug('logged into server');
-        client.exec(INSTALL_COMMAND, (e: Error, stream: ssh2.Channel) => {
+        connection.exec(INSTALL_COMMAND, (e: Error, stream: ssh2.Channel) => {
           if (e) {
+            connection.end();
             R({
               message: 'could not execute command: ' + e.message
             });
             return;
           }
           stream.on('end', () => {
+            connection.end();
             R({
               message: 'invitation URL not found'
             });
@@ -74,9 +76,9 @@ class CloudInstaller {
           message: 'could not login: ' + e.message
         });
       }).on('end', () => {
-        log.debug('end');
+        log.debug('connection end');
       }).on('close', (hadError: boolean) => {
-        log.debug('close (hadError: %1)', hadError);
+        log.debug('connection close, with%1 error', (hadError ? '' : 'out'));
       }).connect(connectConfig);
     });
   }

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -465,9 +465,7 @@ class Connection {
           ZORK_HOST, ZORK_PORT, (e: Error, stream: ssh2.Channel) => {
             if (e) {
               this.close();
-              R({
-                message: 'error establishing tunnel: ' + e.message
-              });
+              R(new Error('error establishing tunnel: ' + e.toString()));
               return;
             }
             this.setState_(ConnectionState.WAITING_FOR_PING);
@@ -484,9 +482,8 @@ class Connection {
                     F();
                   } else {
                     this.close();
-                    R({
-                      message: 'expected ping on login, received: ' + reply
-                    });
+                    R(new Error('did not receive ping from server on login: ' +
+                      reply));
                   }
                   break;
                 case ConnectionState.ESTABLISHED:
@@ -513,9 +510,7 @@ class Connection {
               // TODO: does this occur outside of startup, i.e. should it always reject?
               log.warn('%1: tunnel error: %2', this.name_, e);
               this.close();
-              R({
-                message: 'could not establish tunnel: ' + e.message
-              });
+              R(new Error('could not establish tunnel: ' + e.toString()));
             }).on('end', () => {
               // Occurs when the stream is "over" for any reason, including
               // failed connection.
@@ -536,9 +531,7 @@ class Connection {
         // TODO: does this occur outside of startup, i.e. should it always reject?
         log.warn('%1: connection error: %2', this.name_, e);
         this.close();
-        R({
-          message: 'could not login: ' + e.message
-        });
+        R(new Error('could not login: ' + e.toString()));
       }).on('end', () => {
         // Occurs when the connection is "over" for any reason, including
         // failed connection.

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -465,7 +465,9 @@ class Connection {
           ZORK_HOST, ZORK_PORT, (e: Error, stream: ssh2.Channel) => {
             if (e) {
               this.close();
-              R(new Error('error establishing tunnel: ' + e.toString()));
+              R({
+                message: 'error establishing tunnel: ' + e.message
+              });
               return;
             }
             this.setState_(ConnectionState.WAITING_FOR_PING);
@@ -482,8 +484,9 @@ class Connection {
                     F();
                   } else {
                     this.close();
-                    R(new Error('did not receive ping from server on login: ' +
-                      reply));
+                    R({
+                      message: 'expected ping on login, received: ' + reply
+                    });
                   }
                   break;
                 case ConnectionState.ESTABLISHED:
@@ -510,7 +513,9 @@ class Connection {
               // TODO: does this occur outside of startup, i.e. should it always reject?
               log.warn('%1: tunnel error: %2', this.name_, e);
               this.close();
-              R(new Error('could not establish tunnel: ' + e.toString()));
+              R({
+                message: 'could not establish tunnel: ' + e.message
+              });
             }).on('end', () => {
               // Occurs when the stream is "over" for any reason, including
               // failed connection.
@@ -531,7 +536,9 @@ class Connection {
         // TODO: does this occur outside of startup, i.e. should it always reject?
         log.warn('%1: connection error: %2', this.name_, e);
         this.close();
-        R(new Error('could not login: ' + e.toString()));
+        R({
+          message: 'could not login: ' + e.message
+        });
       }).on('end', () => {
         // Occurs when the connection is "over" for any reason, including
         // failed connection.


### PR DESCRIPTION
This adds a class which will install uProxy on a server via SSH. The process is as similar as possible to a manual install (being described in an upcoming blog post). I've also extended the deployer sample app to use it.

Note that there is some weirdness with brand new Digital Ocean instances: for several minutes after creation, network access is flaky (`git`, `curl`, `host`, etc., fail or timeout or run extremely slowly). Still trying to figure that out.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/349)
<!-- Reviewable:end -->
