### PR TITLE
polish for cloud social provider SSH use

### DIFF
--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -538,7 +538,7 @@ class Connection {
         log.debug('%1: connection end', this.name_);
         this.setState_(ConnectionState.TERMINATED);
       }).on('close', (hadError: boolean) => {
-        log.debug('%1: connection close, with%1 error', this.name_, (hadError ? '' : 'out'));
+        log.debug('%1: connection close, with%2 error', this.name_, (hadError ? '' : 'out'));
         this.setState_(ConnectionState.TERMINATED);
       }).connect(connectConfig);
     });

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -367,11 +367,15 @@ export class CloudSocialProvider {
   public inviteUser = (clientId: string): Promise<Object> => {
     log.debug('inviteUser');
     if (!(clientId in this.savedContacts_)) {
-      return Promise.reject(new Error('unknown cloud instance ' + clientId));
+      return Promise.reject({
+        message: 'unknown cloud instance ' + clientId
+      });
     }
     if (this.savedContacts_[clientId].invite.user !== ADMIN_USERNAME) {
-      return Promise.reject(new Error('user is logged in as non-admin user ' +
-          this.savedContacts_[clientId].invite.user));
+      return Promise.reject({
+        message: 'user is logged in as non-admin user ' +
+            this.savedContacts_[clientId].invite.user
+      });
     }
     return this.reconnect_(this.savedContacts_[clientId].invite).then(
         (connection: Connection) => {
@@ -436,7 +440,9 @@ class Connection {
   // TODO: timeout
   public connect = (): Promise<void> => {
     if (this.state_ !== ConnectionState.NEW) {
-      return Promise.reject(new Error('can only connect in NEW state'));
+      return Promise.reject({
+        message: 'can only connect in NEW state'
+      });
     }
     this.state_ = ConnectionState.CONNECTING;
 
@@ -465,7 +471,9 @@ class Connection {
           ZORK_HOST, ZORK_PORT, (e: Error, stream: ssh2.Channel) => {
             if (e) {
               this.close();
-              R(new Error('error establishing tunnel: ' + e.toString()));
+              R({
+                message: 'error establishing tunnel: ' + e.message
+              });
               return;
             }
             this.setState_(ConnectionState.WAITING_FOR_PING);
@@ -482,8 +490,9 @@ class Connection {
                     F();
                   } else {
                     this.close();
-                    R(new Error('did not receive ping from server on login: ' +
-                      reply));
+                    R({
+                      message: 'did not receive ping from server on login: ' + reply
+                    });
                   }
                   break;
                 case ConnectionState.ESTABLISHED:
@@ -510,7 +519,9 @@ class Connection {
               // TODO: does this occur outside of startup, i.e. should it always reject?
               log.warn('%1: tunnel error: %2', this.name_, e);
               this.close();
-              R(new Error('could not establish tunnel: ' + e.toString()));
+              R({
+                message: 'could not establish tunnel: ' + e.message
+              });
             }).on('end', () => {
               // Occurs when the stream is "over" for any reason, including
               // failed connection.
@@ -531,7 +542,9 @@ class Connection {
         // TODO: does this occur outside of startup, i.e. should it always reject?
         log.warn('%1: connection error: %2', this.name_, e);
         this.close();
-        R(new Error('could not login: ' + e.toString()));
+        R({
+          message: 'could not login: ' + e.message
+        });
       }).on('end', () => {
         // Occurs when the connection is "over" for any reason, including
         // failed connection.

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -595,7 +595,7 @@ class Connection {
           R({
             message: 'command output to STDERR: ' + data.toString()
           });
-        }).on('end', (code: any, signal: any) => {
+        }).on('end', () => {
           log.debug('%1: exec stream end', this.name_);
         });
       });

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -26,6 +26,9 @@ const STORAGE_KEY = 'cloud-social-contacts';
 const ADMIN_USERNAME = 'giver';
 const REGULAR_USERNAME = 'getter';
 
+// Timeout for establishing an SSH connection.
+const CONNECT_TIMEOUT_MS = 10000;
+
 // Credentials for accessing a cloud instance.
 // The serialised, base64 form is distributed amongst users.
 // TODO: add (private) keys, for key-based auth
@@ -450,6 +453,7 @@ class Connection {
       host: this.invite_.host,
       port: SSH_SERVER_PORT,
       username: this.invite_.user,
+      readyTimeout: CONNECT_TIMEOUT_MS,
       // Remaining fields only for type-correctness.
       tryKeyboard: false,
       debug: undefined
@@ -464,6 +468,7 @@ class Connection {
 
     return new Promise<void>((F, R) => {
       this.client_.on('ready', () => {
+        // TODO: set a timeout here, too
         this.setState_(ConnectionState.ESTABLISHING_TUNNEL);
         this.client_.forwardOut(
           // TODO: since we communicate using the stream, what does this mean?


### PR DESCRIPTION
Applying some polish, based on what I learned while working on the installer:
https://github.com/uProxy/uproxy-lib/pull/349

Main two things:
 * reject with `{message: 'xxx'}` objects (for freedom)
 * remove some handlers on the SSH objects which don't actually get called in practise

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/350)
<!-- Reviewable:end -->
