### PR TITLE
whitelist candidate lines

### DIFF
--- a/src/churn/candidate.spec.ts
+++ b/src/churn/candidate.spec.ts
@@ -101,4 +101,24 @@ describe("extractEndpointFromCandidateLine", function() {
     // Roundtrip
     expect(c.toRTCIceCandidate()).toEqual(rtcIceCandidate);
   });
+
+  // Ensure un-whitelisted extensions are stripped:
+  //   https://github.com/uProxy/uproxy/issues/2167
+  it('un-whitelisted extensions are removed', () => {
+    const rtcIceCandidate = {
+      candidate: 'candidate:1302982778 1 tcp 1518214911 172.29.18.131 0 typ host generation 0 ufrag abc123',
+      sdpMid: '',
+      sdpMLineIndex: 0
+    };
+    const c = Candidate.fromRTCIceCandidate(rtcIceCandidate);
+    expect(c.extensions.length).toEqual(1);
+    expect(c.extensions[0]).toEqual({ key: 'generation', value: '0' });
+
+    // Roundtrip, sanitised.
+    expect(c.toRTCIceCandidate()).toEqual({
+      candidate: 'candidate:1302982778 1 tcp 1518214911 172.29.18.131 0 typ host generation 0',
+      sdpMid: '',
+      sdpMLineIndex: 0
+    });
+  });
 });

--- a/src/churn/candidate.ts
+++ b/src/churn/candidate.ts
@@ -12,6 +12,15 @@ export interface IceExtension {
   value: string;
 }
 
+// The unexpected introduction of new fields has impacted churn
+// in the past, e.g. ufrag:
+//   https://github.com/uProxy/uproxy/issues/2167
+// To help prevent similar breakages re-occurring, we generally
+// remove fields that aren't defined in the spec. Exceptions are
+// made for TCP candidates and Chrome's generation field, which
+// has been around forever.
+const EXTENSION_WHITELIST = ['tcptype', 'generation'];
+
 // Represents an RTCIceCandidate object from the WebRTC spec:
 //   http://www.w3.org/TR/webrtc/#rtcicecandidate-type
 // This encapsulates a candidate as described in section 15.1 of the ICE RFC
@@ -136,10 +145,14 @@ export class Candidate {
     }
 
     for (; i < tokens.length; i += 2) {
-      c.extensions.push({
-        key: tokens[i],
-        value: tokens[i + 1]
-      });
+      const key = tokens[i];
+      const value = tokens[i + 1];
+      if (EXTENSION_WHITELIST.indexOf(key) >= 0) {
+        c.extensions.push({
+          key: key,
+          value: value
+        });
+      }
     }
 
     c.sdpMid = rtcIceCandidate.sdpMid;


### PR DESCRIPTION
Introduce a whitelist for candidate fields, the unexpected introduction of which has caused us some problems:
https://github.com/uProxy/uproxy/issues/2167

Seems to fix the problem we've been seeing with Chrome 49+:

| * | chrome-stable | chrome-beta | chrome-canary | firefox-stable | firefox-beta | firefox-canary |
| --: | :-: | :-: | :-: | :-: | :-: | :-: |
| chrome-stable | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| chrome-beta | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| chrome-canary | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| firefox-stable | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| firefox-beta | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| firefox-canary | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/353)

<!-- Reviewable:end -->
