### PR TITLE
retry for SSH connections, with a re-useable library

### DIFF
--- a/src/promises/promises.spec.ts
+++ b/src/promises/promises.spec.ts
@@ -1,0 +1,49 @@
+/// <reference path='../../../third_party/typings/es6-promise/es6-promise.d.ts' />
+/// <reference path='../../../third_party/typings/jasmine/jasmine.d.ts' />
+
+import promises = require('./promises');
+
+describe('retry', () => {
+  const MAX_ATTEMPTS = 5;
+  const RETURN_VALUE = 'hello';
+  const REJECT_MESSAGE = 'goodbye';
+
+  it('only calls successful function once', (done) => {
+    const f = jasmine.createSpy('spy');
+    f.and.returnValue(Promise.resolve(RETURN_VALUE));
+    promises.retry(f, MAX_ATTEMPTS).then((result: string) => {
+      expect(f.calls.count()).toEqual(1);
+      expect(result).toEqual(RETURN_VALUE);
+      done();
+    });
+  });
+
+  it('calls multiple times until success', (done) => {
+    const NUM_CALLS_BEFORE_SUCCESS = 3;
+    let callCount = 0;
+    const f = jasmine.createSpy('spy');
+    f.and.callFake(() => {
+      callCount++;
+      if (callCount === NUM_CALLS_BEFORE_SUCCESS) {
+        return Promise.resolve(RETURN_VALUE);
+      } else {
+        return Promise.reject('error');
+      }
+    });
+    promises.retry(f, NUM_CALLS_BEFORE_SUCCESS + 1).then((result: string) => {
+      expect(f.calls.count()).toEqual(NUM_CALLS_BEFORE_SUCCESS);
+      expect(result).toEqual(RETURN_VALUE);
+      done();
+    });
+  });
+
+  it('stops calling after the max number of failures', (done) => {
+    const f = jasmine.createSpy('spy');
+    f.and.returnValue(Promise.reject(new Error(REJECT_MESSAGE)));
+    promises.retry(f, MAX_ATTEMPTS).catch((e: Error) => {
+      expect(f.calls.count()).toEqual(MAX_ATTEMPTS);
+      expect(e.message).toEqual(REJECT_MESSAGE);
+      done();
+    });
+  });
+});

--- a/src/promises/promises.ts
+++ b/src/promises/promises.ts
@@ -1,0 +1,14 @@
+/// <reference path='../../../third_party/typings/es6-promise/es6-promise.d.ts' />
+
+// Invokes f up to maxAttempts number of times, resolving with its result
+// on the first success and rejecting on maxAttempts-th failure.
+export const retry = <T>(f: () => Promise<T>, maxAttempts: number): Promise<T> => {
+  return f().catch((e:Error) => {
+    --maxAttempts;
+    if (maxAttempts > 0) {
+      return retry(f, maxAttempts);
+    } else {
+      return Promise.reject(e);
+    }
+  });
+};

--- a/src/promises/promises.ts
+++ b/src/promises/promises.ts
@@ -12,3 +12,20 @@ export const retry = <T>(f: () => Promise<T>, maxAttempts: number): Promise<T> =
     }
   });
 };
+
+// Invokes f with exponential backoff between retries, resolving with its result
+// on the first success and rejecting on maxAttempts-th failure.
+export const retryWithExponentialBackoff = <T>(f: () => Promise<T>,
+    maxIntervalMs: number, initialIntervalMs: number): Promise<T> => {
+  return f().catch((e: Error) => {
+    initialIntervalMs *= 2;
+    if (initialIntervalMs > maxIntervalMs) {
+      return Promise.reject(e);
+    }
+    return new Promise<T>((F, R) => {
+      setTimeout(() => {
+        retryWithExponentialBackoff(f, maxIntervalMs, initialIntervalMs).then(F, R);
+      }, initialIntervalMs);
+    });
+  });
+};


### PR DESCRIPTION
This fixes the case where, immediately after an install, the SSH container isn't **quite** ready to accept connections.

Also some refactoring, solving https://github.com/uProxy/uproxy/issues/2295.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/371)

<!-- Reviewable:end -->
