### PR TITLE
go back to the docker slug

### DIFF
--- a/src/cloud/digitalocean/provisioner.ts
+++ b/src/cloud/digitalocean/provisioner.ts
@@ -14,7 +14,7 @@ const POLL_TIMEOUT: number = 5000; //milliseconds
 //     console.log('available images: ' + JSON.stringify(resp, undefined, 2));
 //   });
 const DEFAULT_REGION: string = 'nyc1';
-const DEFAULT_IMAGE: string = 'ubuntu-14-04-x64';
+const DEFAULT_IMAGE: string = 'docker';
 const DEFAULT_SIZE: string = '1gb';
 
 const STATUS_CODES: { [k: string]: string; } = {


### PR DESCRIPTION
DigitalOcean's Docker slug has been updated, meaning we can now safely use it and avoid the time taken to install Docker on the droplet. Just tested this and was able to create a cloud server in seven minutes.

No changes required to the Docker scripts; I can update the blog post when this is in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/374)
<!-- Reviewable:end -->
