### PR TITLE
fixes for SSH on firefox

### DIFF
--- a/src/cloud/install/installer.ts
+++ b/src/cloud/install/installer.ts
@@ -120,8 +120,14 @@ class CloudInstaller {
         });
       }).on('end', () => {
         log.debug('connection end');
+        R({
+          message: 'connection end without invitation URL'
+        });
       }).on('close', (hadError: boolean) => {
         log.debug('connection close, with%1 error', (hadError ? '' : 'out'));
+        R({
+          message: 'connection close without invitation URL'
+        });
       }).connect(connectConfig);
     });
   }

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -26,8 +26,9 @@ const STORAGE_KEY = 'cloud-social-contacts';
 // Timeout for establishing an SSH connection.
 const CONNECT_TIMEOUT_MS = 10000;
 
-// Maximum number of times to try establishing an SSH connection.
-const MAX_CONNECT_ATTEMPTS = 3;
+// Retry timing for SSH connection establishment.
+const INITIAL_CONNECTION_INTERVAL_MS = 500;
+const MAX_CONNECTION_INTERVAL_MS = 10000;
 
 // Credentials for accessing a cloud instance.
 // The serialised, base64 form is distributed amongst users.
@@ -218,8 +219,9 @@ export class CloudSocialProvider {
       });
     };
         
-    this.clients_[invite.host] = promises.retry(connect,
-        MAX_CONNECT_ATTEMPTS).then((connection:Connection) => {
+    this.clients_[invite.host] = promises.retryWithExponentialBackoff(connect,
+        MAX_CONNECTION_INTERVAL_MS, INITIAL_CONNECTION_INTERVAL_MS).then(
+        (connection:Connection) => {
       log.info('connected to zork on %1', invite.host);
 
       // Fetch the banner, if available, then emit an instance message.

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -542,9 +542,15 @@ class Connection {
       }).on('end', () => {
         log.debug('%1: connection end', this.name_);
         this.setState_(ConnectionState.TERMINATED);
+        R({
+          message: 'connection end without ping'
+        });
       }).on('close', (hadError: boolean) => {
         log.debug('%1: connection close, with%2 error', this.name_, (hadError ? '' : 'out'));
         this.setState_(ConnectionState.TERMINATED);
+        R({
+          message: 'connection close without ping'
+        });
       }).connect(connectConfig);
     });
   }


### PR DESCRIPTION
Two main differences:
1. Unlike on Chrome, connection failures are reported **instantly** if the SSH server is not ready. This means a simple retry loop fails in a matter of a few ms - so exponential backoff is required.
2. When this happens, no error is reported...weird. This has the effect of leaving the Promise unresolved forever; fortunately, the `end` and `close` events are still received. So, call the reject function when those events are received (this works because calling the reject function has no effect if the fulfill function has already been called).

With these two changes, I can successfully create a cloud server in Firefox.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/376)

<!-- Reviewable:end -->
