### PR TITLE
move to grunt-browserify, with fix for node tcp shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "freedom-pgp-e2e": "^0.6.1",
     "freedom-xhr": "0.0.5",
     "grunt": "^0.4.5",
-    "grunt-browserify": "^4.0.0",
+    "grunt-browserify": "^5.0.0",
     "grunt-contrib-clean": "^0.7.0",
     "grunt-contrib-coffee": "^0.13.0",
     "grunt-contrib-copy": "^0.8.0",

--- a/src/cloud/social/shim/tcp.js
+++ b/src/cloud/social/shim/tcp.js
@@ -82,8 +82,8 @@ FreedomTCP.prototype._writeNative = function(req, data) {
 };
 
 FreedomTCP.prototype.writeBuffer = function(req, buf) {
-  var data = buf.toArrayBuffer();
-  this._writeNative(req, data);
+  // buf is a NodeJS Buffer, the buffer field of which is a Uint8Array.
+  this._writeNative(req, buf.buffer);
 };
 
 FreedomTCP.prototype.writeAsciiString = function(req, s) {


### PR DESCRIPTION
Little code health exercise: move to grunt-browserify 5.x.

This revision is based on browserify 13 - the only incompatibility I've seen is that `toArrayBuffer` was removed; however, since Buffer now implements the Uint8Array interface I was able to just access its buffer field which is probably a little faster:
https://github.com/substack/node-browserify/blob/master/changelog.markdown#1300

BTW, some background on why they removed that method:
https://github.com/nodejs/node-v0.x-archive/issues/7609#issuecomment-42903457

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/381)

<!-- Reviewable:end -->
