### PR TITLE
remove firefox integration tests from dist build owing to flakiness

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -424,6 +424,7 @@ config =
         outDir: devBuildPath + '/integration-tests/socks-echo/jasmine_chromeapp_slow/'
         keepRunner: true
 
+  # Not currently included in any target due to flakiness.
   jasmine_firefoxaddon:
     tests: [
       devBuildPath + '/integration-tests/tcp/tcp.core-env.spec.static.js'
@@ -592,7 +593,6 @@ taskManager.add 'socksEchoIntegrationTest', [
 taskManager.add 'integration_test', [
   'tcpIntegrationTest'
   'socksEchoIntegrationTest'
-  'jasmine_firefoxaddon'  # Currently only TCP test
 ]
 
 taskManager.add 'lint', ['tslint']


### PR DESCRIPTION
They're too flaky and I'm trying hard to make the release process to be as smooth as possible.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/393)

<!-- Reviewable:end -->
