### PR TITLE
remove unused regex2dfa .d.ts

### DIFF
--- a/third_party/regex2dfa/regex2dfa.d.ts
+++ b/third_party/regex2dfa/regex2dfa.d.ts
@@ -1,6 +1,0 @@
-// Type definitions for regex2dfa 0.1.6
-// github url: https://github.com/kpdyer/regex2dfa/
-
-declare module "regex2dfa" {
-  function regex2dfa(regex:string):string;
-}


### PR DESCRIPTION
Missed this when I was doing https://github.com/uProxy/uproxy-lib/pull/395

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/402)

<!-- Reviewable:end -->
