### PR TITLE
up node to 4.4 LTS on shippable/travis

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -1,7 +1,7 @@
 build_image: freedomjs/freedom
 language: node_js
 node_js:
-- '0.10'
+- '4.4'
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
- - "0.10"
+ - "4.4"
 before_install:
  - npm install -g grunt-cli
 install:


### PR DESCRIPTION
See https://github.com/uProxy/uproxy/issues/2396 for background.

Tests still pass (on Travis - Shippable is disabled at the moment), so this could be fine to just merge as is. However if you want me to look into dealing with the C++11 error message (switching to Trusty, or trying those other config parameters), let me know. Thanks!

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/403)

<!-- Reviewable:end -->
