### PR TITLE
cloud social provider hardening

### DIFF
--- a/src/cloud/install/installer.ts
+++ b/src/cloud/install/installer.ts
@@ -5,6 +5,7 @@ require('../social/monkey/process');
 import arraybuffers = require('../../arraybuffers/arraybuffers');
 import linefeeder = require('../../net/linefeeder');
 import logging = require('../../logging/logging');
+import Pinger = require('../../net/pinger');
 import queue = require('../../handler/queue');
 
 // https://github.com/borisyankov/DefinitelyTyped/blob/master/ssh2/ssh2-tests.ts
@@ -143,6 +144,12 @@ class CloudInstaller {
           message: 'connection close without invitation URL'
         });
       }).connect(connectConfig);
+    }).then((invite: any) => {
+      // It can take several seconds before the SSH server running
+      // in the new Docker container becomes active.
+      return new Pinger(host, 5000).ping().then(() => {
+        return invite;
+      });
     });
   }
 }

--- a/src/cloud/social/provider.ts
+++ b/src/cloud/social/provider.ts
@@ -289,7 +289,9 @@ export class CloudSocialProvider {
       log.debug('saved contacts');
     }).catch((e) => {
       log.error('could not save contacts: %1', e);
-      Promise.reject(e);
+      Promise.reject({
+        message: e.message
+      });
     });
   }
 
@@ -322,7 +324,9 @@ export class CloudSocialProvider {
           //       the instance (safe because all we've done is run ping).
           log.info('new proxying session %1', payload.proxyingId);
           if (!(destinationClientId in this.savedContacts_)) {
-            return Promise.reject(new Error('unknown client ' + destinationClientId));
+            return Promise.reject({
+              message: 'unknown client ' + destinationClientId
+            });
           }
           return this.reconnect_(this.savedContacts_[destinationClientId].invite).then(
               (connection: Connection) => {
@@ -335,30 +339,39 @@ export class CloudSocialProvider {
               connection.sendMessage(JSON.stringify(payload));
             });
           } else {
-            return Promise.reject(new Error('unknown client ' + destinationClientId));
+            return Promise.reject({
+              message: 'unknown client ' + destinationClientId
+            });
           }
         }
       } else {
-        return Promise.reject(new Error('message has no or wrong type field'));
+        return Promise.reject({
+          message: 'message has no or wrong type field'
+        });
       }
     } catch (e) {
-      return Promise.reject(new Error('could not de-serialise message: ' + e.message));
+      return Promise.reject({
+        message: 'could not de-serialise message: ' + e.message
+      });
     }
   }
 
   public clearCachedCredentials = (): Promise<void> => {
-    return Promise.reject(
-        new Error('clearCachedCredentials unimplemented'));
+    return Promise.reject({
+      message: 'clearCachedCredentials unimplemented'
+    });
   }
 
   public getUsers = (): Promise<freedom.Social.Users> => {
-    return Promise.reject(
-        new Error('getUsers unimplemented'));
+    return Promise.reject({
+      message: 'getUsers unimplemented'
+    });
   }
 
   public getClients = (): Promise<freedom.Social.Clients> => {
-    return Promise.reject(
-        new Error('getClients unimplemented'));
+    return Promise.reject({
+      message: 'getClients unimplemented'
+    });
   }
 
   public logout = (): Promise<void> => {
@@ -398,17 +411,21 @@ export class CloudSocialProvider {
     log.debug('acceptUserInvitation');
     try {
       var invite = <Invite>JSON.parse(inviteJson);
+      log.debug('decoded invite: %1', invite);
       return this.reconnect_(invite).then((connection: Connection) => {
         // Return nothing for type checking purposes.
       });
     } catch (e) {
-      return Promise.reject(new Error('could not parse invite code: ' + e.message));
+      return Promise.reject({
+        message: 'could not parse invite code: ' + e.message
+      });
     }
   }
 
   public blockUser = (userId: string): Promise<void> => {
-    return Promise.reject(
-        new Error('blockUser unimplemented'));
+    return Promise.reject({
+      message: 'blockUser unimplemented'
+    });
   }
 
   // Removes a cloud contact from storage
@@ -599,7 +616,9 @@ class Connection {
   private exec_ = (command: string): Promise<string> => {
     log.debug('%1: execute command: %2', this.name_, command);
     if (this.state_ !== ConnectionState.ESTABLISHED) {
-      return Promise.reject(new Error('can only execute commands in ESTABLISHED state'));
+      return Promise.reject({
+        message: 'can only execute commands in ESTABLISHED state'
+      });
     }
     return new Promise<string>((F, R) => {
       this.connection_.exec(command, (e: Error, stream: ssh2.Channel) => {

--- a/src/net/pinger.ts
+++ b/src/net/pinger.ts
@@ -1,0 +1,51 @@
+/// <reference path='../../../third_party/typings/browser.d.ts' />
+
+import logging = require('../logging/logging');
+import promises = require('../promises/promises');
+
+declare const freedom: freedom.FreedomInModuleEnv;
+
+var log: logging.Log = new logging.Log('pinger');
+
+const DEFAULT_TIMEOUT_SECS = 60;
+const DEFAULT_INTERVAL_MS = 1000;
+
+// "Pings" - in an nmap sense - a port until a TCP connection can be established.
+class Pinger {
+  constructor(
+    private host_: string,
+    private port_: number,
+    private timeout_= DEFAULT_TIMEOUT_SECS) { }
+
+  // Resolves once a connection has been established, rejecting if
+  // no connection can be made within the timeout.
+  public ping = (): Promise<void> => {
+    log.debug('pinging %1:%2...', this.host_, this.port_);
+
+    return promises.retry(() => {
+      const socket = freedom['core.tcpsocket']();
+
+      const destructor = () => {
+        try {
+          freedom['core.tcpsocket'].close(socket);
+        } catch (e) {
+          console.warn('error destroying socket: ' + e.message);
+        }
+      };
+
+      // TODO: Worth thinking about timeouts here but because this times
+      //       out almost immediately if nothing is listening on the port,
+      //       it works well for our purposes.
+      return socket.connect(this.host_, this.port_).then((unused: any) => {
+        log.debug('connected to %1:%2', this.host_, this.port_);
+        destructor();
+      }, (e: Error) => {
+        log.debug('connection failed to %1:%2', this.host_, this.port_);
+        destructor();
+        throw e;
+      });
+    }, this.timeout_, DEFAULT_INTERVAL_MS);
+  }
+}
+
+export = Pinger;


### PR DESCRIPTION
Three main things:
- all rejections should use the weird freedomjs-style `{message: 'whatever'};` objects
- save contacts immediately, so there is virtually no chance of a new cloud server failing to add the contacts list for, e.g. temporary SSH failure https://github.com/uProxy/uproxy/issues/2377
- factor out the "pinging" logic from the provisioner and have the installer use it too, allowing us remove the retry logic altogether from the social provider https://github.com/uProxy/uproxy/issues/2419

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/412)

<!-- Reviewable:end -->
