### PR TITLE
make installer ssh keepalive much longer

### DIFF
--- a/src/cloud/install/installer.ts
+++ b/src/cloud/install/installer.ts
@@ -34,7 +34,7 @@ const MAX_CONNECTION_INTERVAL_MS = 10000;
 // in case the server is destroyed during installation, e.g.
 // when the user cancels install.
 const KEEPALIVE_INTERVAL_MS = 1000;
-const KEEPALIVE_MAX_FAILURES = 5;
+const KEEPALIVE_MAX_FAILURES = 120;
 
 // Installs uProxy on a server, via SSH.
 // The process is as close as possible to a manual install


### PR DESCRIPTION
5 seconds works just fine on my powerful desktop but I've observed several failures on my much less powerful OSX laptop. At two minutes I don't see this.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/413)

<!-- Reviewable:end -->
