### PR TITLE
trap errors coming from nodejs tcp socket read handlers

### DIFF
--- a/src/cloud/social/shim/tcp.js
+++ b/src/cloud/social/shim/tcp.js
@@ -25,7 +25,11 @@ FreedomTCP.prototype._onRead = function(readInfo) {
   //console.warn('read ' + len +': ' + str);
 
   if (this.reading) {
-    this.onread(len, buf);
+    try {
+      this.onread(len, buf);
+    } catch (e) {
+      console.error('nodejs socket read handler raised en error', e);
+    }
   } else {
     this.bufferedReads.push({buf: buf, len: len});
   }


### PR DESCRIPTION
I believe this will workaround https://github.com/uProxy/uproxy/issues/2425.

Stack trace:

![screen shot 2016-05-17 at 4 42 18 pm](https://cloud.githubusercontent.com/assets/5142116/15340004/376cc588-1c55-11e6-9883-515445fe32f6.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-lib/414)

<!-- Reviewable:end -->
